### PR TITLE
Fix superseded concepts feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,6 @@ jobs:
           - "2.5"
           - "2.4"
 
-    name: Run tests
-    runs-on: ubuntu-latest
-
     steps:
       - name: Fetch source code
         uses: actions/checkout@v2

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -62,7 +62,7 @@ module Glossarist
           .compact
           .each { |lc| concept.add_l10n lc }
 
-        concept.l10n("eng")&.superseded_concepts = hash.dig("related")
+        concept.l10n("eng")&.superseded_concepts = hash.dig("related") || []
       end
     end
     # rubocop:enable Metrics/AbcSize, Style/RescueModifier

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -62,7 +62,7 @@ module Glossarist
           .compact
           .each { |lc| concept.add_l10n lc }
 
-        concept.l10n("eng")&.superseded_concepts = hash.dig("related_concepts")
+        concept.l10n("eng")&.superseded_concepts = hash.dig("related")
       end
     end
     # rubocop:enable Metrics/AbcSize, Style/RescueModifier

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -72,6 +72,7 @@ module Glossarist
       @examples = []
       @notes = []
       @designations = []
+      @superseded_concepts = []
       super
     end
 

--- a/spec/concept_spec.rb
+++ b/spec/concept_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe Glossarist::Concept do
       src = {
         "termid" => "123-45",
         "term" => "Example Designation",
+        "related" => [
+          {
+            "type" => "supersedes",
+            "ref" => {
+              "source" => "Example Source",
+              "id" => "12345",
+              "version" => "7",
+            },
+          },
+        ],
         "eng" => {
           "id" => "123-45",
           "language_code" => "eng",
@@ -50,6 +60,8 @@ RSpec.describe Glossarist::Concept do
       expect(eng).to be_kind_of(Glossarist::LocalizedConcept)
       expect(eng.definition).to eq("Example Definition")
       expect(eng.terms.dig(0, "designation")).to eq("Example Designation")
+      expect(eng.superseded_concepts.dig(0, "type")).to eq("supersedes")
+      expect(eng.superseded_concepts.dig(0, "ref", "id")).to eq("12345")
     end
   end
 end

--- a/spec/localized_concept_spec.rb
+++ b/spec/localized_concept_spec.rb
@@ -85,4 +85,13 @@ RSpec.describe Glossarist::LocalizedConcept do
         .to change { subject.examples }.to(["str"])
     end
   end
+
+  describe "#superseded_concepts" do
+    let(:sup) { double("supersession") }
+
+    it "is an array" do
+      expect { subject.superseded_concepts << sup }
+        .to change { subject.superseded_concepts }.to([sup])
+    end
+  end
 end


### PR DESCRIPTION
- Fixes `#superseded_concepts` attribute initialization.
- Fixes superseded concepts deserialization (fixes #7).
- Adds missing tests.