### PR TITLE
Improve YAML (de)serialization

### DIFF
--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -43,8 +43,9 @@ module Glossarist
         "termid" => id,
         "term" => default_designation,
         "related" => related_concepts,
-        **localizations.transform_values(&:to_h),
-      }.compact
+      }
+      .compact
+      .merge(localizations.transform_values(&:to_h))
     end
 
     # @deprecated For legacy reasons only.

--- a/spec/features/serialization_spec.rb
+++ b/spec/features/serialization_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe "Serialization and deserialization" do
+  it "correctly loads concepts from files and writes them too" do
+    collection = Glossarist::Collection.new(path: fixtures_path)
+    collection.load_concepts
+
+    zeus = collection["123-01"]
+    hera = collection["123-02"]
+
+    expect([zeus, hera]).to all be_kind_of(Glossarist::Concept)
+    expect([zeus.l10n("eng"), zeus.l10n("deu"), hera.l10n("eng"),
+      hera.l10n("deu")]).to all be_kind_of(Glossarist::LocalizedConcept)
+
+    expect(zeus.l10n("eng").designations.first["designation"]).to eq("Zeus")
+    expect(hera.l10n("eng").designations.first["designation"]).to eq("Hera")
+    expect(zeus.l10n("eng").superseded_concepts.size).to eq(1)
+    expect(hera.l10n("eng").superseded_concepts.size).to eq(0)
+
+    Dir.mktmpdir do |tmp_path|
+      collection.path = tmp_path
+      collection.save_concepts
+      system "diff", fixtures_path, tmp_path
+      expect($?.exitstatus).to eq(0) # no difference
+    end
+  end
+end

--- a/spec/fixtures/concept-123-01.yaml
+++ b/spec/fixtures/concept-123-01.yaml
@@ -1,0 +1,37 @@
+---
+termid: 123-01
+term: Zeus
+related:
+- type: supersedes
+  ref:
+    source: Mythology
+    id: 123-01
+    version: some older one
+deu:
+  id: 123-01
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: Zeus
+  definition: Oberste olympische Gott der griechischen Mythologie.
+  language_code: deu
+  notes:
+  - Definition nur zu Testzwecken.
+  examples: []
+  entry_status: valid
+  date_accepted: '2021-05-01T00:00:00+00:00'
+  date_amended: '2021-05-01T00:00:00+00:00'
+eng:
+  id: 123-01
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: Zeus
+  definition: Supreme god in ancient Greek mythology.
+  language_code: eng
+  notes:
+  - This definition serves for test purposes only.
+  examples: []
+  entry_status: valid
+  date_accepted: '2021-05-01T00:00:00+00:00'
+  date_amended: '2021-05-01T00:00:00+00:00'

--- a/spec/fixtures/concept-123-02.yaml
+++ b/spec/fixtures/concept-123-02.yaml
@@ -1,0 +1,31 @@
+---
+termid: 123-02
+term: Hera
+deu:
+  id: 123-02
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: Hera
+  definition: Die Gattin und gleichzeitig die Schwester von Zeus.
+  language_code: deu
+  notes:
+  - Definition nur zu Testzwecken.
+  examples: []
+  entry_status: valid
+  date_accepted: '2021-05-01T00:00:00+00:00'
+  date_amended: '2021-05-01T00:00:00+00:00'
+eng:
+  id: 123-02
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: Hera
+  definition: Sister and wife of Zeus.
+  language_code: eng
+  notes:
+  - This definition serves for test purposes only.
+  examples: []
+  entry_status: valid
+  date_accepted: '2021-05-01T00:00:00+00:00'
+  date_amended: '2021-05-01T00:00:00+00:00'

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,0 +1,9 @@
+module FixturesHelper
+  def fixtures_path
+    File.expand_path("../fixtures", __dir__)
+  end
+end
+
+RSpec.configure do |c|
+  c.include FixturesHelper
+end

--- a/spec/unit/concept_spec.rb
+++ b/spec/unit/concept_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Glossarist::Concept do
   end
 
   describe "::from_h" do
-    it "loads concept definition from a Hash" do
+    it "loads concept definition from a hash" do
       src = {
         "termid" => "123-45",
         "term" => "Example Designation",

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -94,4 +94,44 @@ RSpec.describe Glossarist::LocalizedConcept do
         .to change { subject.superseded_concepts }.to([sup])
     end
   end
+
+  describe "#to_h" do
+    it "dumps localized concept definition to a hash" do
+      attrs.replace({
+        id: "123",
+        language_code: "lang",
+        examples: ["ex. one"],
+        notes: ["note one"],
+      })
+
+      retval = subject.to_h
+      expect(retval).to be_kind_of(Hash)
+      expect(retval["language_code"]).to eq("lang")
+      expect(retval["id"]).to eq("123")
+      expect(retval["examples"]).to contain_exactly("ex. one")
+      expect(retval["notes"]).to contain_exactly("note one")
+    end
+  end
+
+  describe "::from_h" do
+    it "loads localized concept definition from a hash" do
+      src = {
+        "id" => "123-45",
+        "language_code" => "eng",
+        "terms" => [
+          {
+            "designation" => "Example Designation",
+            "type" => "expression",
+            "normative_status" => "preferred",
+          },
+        ],
+        "definition" => "Example Definition",
+      }
+
+      retval = described_class.from_h(src)
+      expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
+      expect(retval.definition).to eq("Example Definition")
+      expect(retval.terms.dig(0, "designation")).to eq("Example Designation")
+    end
+  end
 end


### PR DESCRIPTION
- Rewrite existing unit tests, and add missing ones
- Add feature tests to cover the whole process
- Fix compatibility with Ruby 2.4–2.6 (`Hash#merge` instead of double splat)