### PR TITLE
Improve unit tests

### DIFF
--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -100,6 +100,7 @@ RSpec.describe Glossarist::LocalizedConcept do
       attrs.replace({
         id: "123",
         language_code: "lang",
+        terms: [{"some" => "designation"}, {"another" => "designation"}],
         examples: ["ex. one"],
         notes: ["note one"],
       })
@@ -108,6 +109,8 @@ RSpec.describe Glossarist::LocalizedConcept do
       expect(retval).to be_kind_of(Hash)
       expect(retval["language_code"]).to eq("lang")
       expect(retval["id"]).to eq("123")
+      expect(retval["terms"]).to eq([
+        {"some" => "designation"}, {"another" => "designation"}])
       expect(retval["examples"]).to eq(["ex. one"])
       expect(retval["notes"]).to eq(["note one"])
     end

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -108,8 +108,8 @@ RSpec.describe Glossarist::LocalizedConcept do
       expect(retval).to be_kind_of(Hash)
       expect(retval["language_code"]).to eq("lang")
       expect(retval["id"]).to eq("123")
-      expect(retval["examples"]).to contain_exactly("ex. one")
-      expect(retval["notes"]).to contain_exactly("note one")
+      expect(retval["examples"]).to eq(["ex. one"])
+      expect(retval["notes"]).to eq(["note one"])
     end
   end
 


### PR DESCRIPTION
- Improve expectations when testing (de)serialization methods.
- Extract unit tests for `Concept#default_designation`.

These test changes are prerequisites for any further improvements of designations.