### PR TITLE
Support multiple sources in Localized Concepts

### DIFF
--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -36,7 +36,7 @@ module Glossarist
 
     # @todo Right now accepts hashes for legacy reasons, but they will be
     #   replaced with dedicated classes.
-    # @return [Hash]
+    # @return [Array<Hash>]
     attr_accessor :authoritative_source
 
     # Must be one of the following:

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -87,7 +87,8 @@ module Glossarist
         "examples" => examples,
         "entry_status" => entry_status,
         "classification" => classification,
-        "authoritative_source" => authoritative_source,
+        "authoritative_source" =>
+          (authoritative_source if authoritative_source&.any?),
         "date_accepted" => date_accepted,
         "date_amended" => date_amended,
         "review_date" => review_date,

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -73,6 +73,7 @@ module Glossarist
       @notes = []
       @designations = []
       @superseded_concepts = []
+      @authoritative_source = []
       super
     end
 

--- a/spec/features/serialization_spec.rb
+++ b/spec/features/serialization_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe "Serialization and deserialization" do
     expect(rook.l10n("eng").designations.last["designation"])
       .to match(/\p{Symbol}/)
 
+    expect(king.l10n("eng").authoritative_source.dig(0, "ref", "source"))
+      .to eq("Wikipedia")
+    expect(king.l10n("eng").authoritative_source.dig(0, "ref", "id"))
+      .to eq("King (chess)")
+    expect(king.l10n("eng").authoritative_source.dig(0, "link"))
+      .to start_with("https")
+
     expect(king.l10n("eng").superseded_concepts.size).to eq(1)
     expect(queen.l10n("eng").superseded_concepts.size).to eq(0)
     expect(rook.l10n("eng").superseded_concepts.size).to eq(0)

--- a/spec/fixtures/concept-chess-02-01.yaml
+++ b/spec/fixtures/concept-chess-02-01.yaml
@@ -25,6 +25,12 @@ eng:
   - Kh6-h7
   - Kh6-g7
   entry_status: valid
+  authoritative_source:
+  - ref:
+      source: Wikipedia
+      id: King (chess)
+      version: 2021-07
+    link: https://en.wikipedia.org/wiki/King_(chess)
   date_accepted: '2021-05-01T00:00:00+00:00'
   date_amended: '2021-05-01T00:00:00+00:00'
 pol:

--- a/spec/fixtures/concept-chess-02-02.yaml
+++ b/spec/fixtures/concept-chess-02-02.yaml
@@ -19,6 +19,12 @@ eng:
   - Qh1-a1
   - Qh1-a8
   entry_status: valid
+  authoritative_source:
+  - ref:
+      source: Wikipedia
+      id: Queen (chess)
+      version: 2021-07
+    link: https://en.wikipedia.org/wiki/Queen_(chess)
   date_accepted: '2021-05-01T00:00:00+00:00'
   date_amended: '2021-05-01T00:00:00+00:00'
 pol:

--- a/spec/fixtures/concept-chess-02-03.yaml
+++ b/spec/fixtures/concept-chess-02-03.yaml
@@ -21,6 +21,12 @@ eng:
   - Rh1-h8
   - Rh1-a1
   entry_status: valid
+  authoritative_source:
+  - ref:
+      source: Wikipedia
+      id: Rook (chess)
+      version: 2021-07
+    link: https://en.wikipedia.org/wiki/Rook_(chess)
   date_accepted: '2021-05-01T00:00:00+00:00'
   date_amended: '2021-05-01T00:00:00+00:00'
 pol:

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -86,6 +86,15 @@ RSpec.describe Glossarist::LocalizedConcept do
     end
   end
 
+  describe "#authoritative_source" do
+    let(:item) { double("source") }
+
+    it "is an array" do
+      expect { subject.authoritative_source << item }
+        .to change { subject.authoritative_source }.to([item])
+    end
+  end
+
   describe "#superseded_concepts" do
     let(:sup) { double("supersession") }
 

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe Glossarist::LocalizedConcept do
         terms: [{"some" => "designation"}, {"another" => "designation"}],
         examples: ["ex. one"],
         notes: ["note one"],
+        authoritative_source: [{"source" => "reference"}],
       })
 
       retval = subject.to_h
@@ -122,6 +123,7 @@ RSpec.describe Glossarist::LocalizedConcept do
         {"some" => "designation"}, {"another" => "designation"}])
       expect(retval["examples"]).to eq(["ex. one"])
       expect(retval["notes"]).to eq(["note one"])
+      expect(retval["authoritative_source"]).to eq([{"source" => "reference"}])
     end
   end
 
@@ -138,12 +140,16 @@ RSpec.describe Glossarist::LocalizedConcept do
           },
         ],
         "definition" => "Example Definition",
+        "authoritative_source" => [
+          {"Example Source" => "Reference"},
+        ],
       }
 
       retval = described_class.from_h(src)
       expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
       expect(retval.definition).to eq("Example Definition")
       expect(retval.terms.dig(0, "designation")).to eq("Example Designation")
+      expect(retval.authoritative_source).to eq([{"Example Source" => "Reference"}])
     end
   end
 end


### PR DESCRIPTION
Concepts may refer to multiple authoritative sources, hence `LocalizedConcept#authoritative_source` must be an array.

Although it worked this way in general, this pull request:

- fixes documentation
- adds unit and feature tests
- ensures proper attribute initialization