### PR TITLE
Rename #sources attribute

### DIFF
--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -91,8 +91,7 @@ module Glossarist
         "examples" => examples,
         "entry_status" => entry_status,
         "classification" => classification,
-        "authoritative_source" =>
-          (authoritative_source if authoritative_source&.any?),
+        "authoritative_source" => (sources if sources&.any?),
         "date_accepted" => date_accepted,
         "date_amended" => date_amended,
         "review_date" => review_date,

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -36,8 +36,12 @@ module Glossarist
 
     # @todo Right now accepts hashes for legacy reasons, but they will be
     #   replaced with dedicated classes.
+    # @todo Alias +authoritative_source+ exists for legacy reasons and may be
+    #   removed.
     # @return [Array<Hash>]
-    attr_accessor :authoritative_source
+    attr_accessor :sources
+    alias :authoritative_source :sources
+    alias :authoritative_source= :sources=
 
     # Must be one of the following:
     # +notValid+, +valid+, +superseded+, +retired+.
@@ -73,7 +77,7 @@ module Glossarist
       @notes = []
       @designations = []
       @superseded_concepts = []
-      @authoritative_source = []
+      @sources = []
       super
     end
 

--- a/spec/features/serialization_spec.rb
+++ b/spec/features/serialization_spec.rb
@@ -26,12 +26,9 @@ RSpec.describe "Serialization and deserialization" do
     expect(rook.l10n("eng").designations.last["designation"])
       .to match(/\p{Symbol}/)
 
-    expect(king.l10n("eng").authoritative_source.dig(0, "ref", "source"))
-      .to eq("Wikipedia")
-    expect(king.l10n("eng").authoritative_source.dig(0, "ref", "id"))
-      .to eq("King (chess)")
-    expect(king.l10n("eng").authoritative_source.dig(0, "link"))
-      .to start_with("https")
+    expect(king.l10n("eng").sources.dig(0, "ref", "source")).to eq("Wikipedia")
+    expect(king.l10n("eng").sources.dig(0, "ref", "id")).to eq("King (chess)")
+    expect(king.l10n("eng").sources.dig(0, "link")).to start_with("https")
 
     expect(king.l10n("eng").superseded_concepts.size).to eq(1)
     expect(queen.l10n("eng").superseded_concepts.size).to eq(0)

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -86,12 +86,12 @@ RSpec.describe Glossarist::LocalizedConcept do
     end
   end
 
-  describe "#authoritative_source" do
+  describe "#sources" do
     let(:item) { double("source") }
 
     it "is an array" do
-      expect { subject.authoritative_source << item }
-        .to change { subject.authoritative_source }.to([item])
+      expect { subject.sources << item }
+        .to change { subject.sources }.to([item])
     end
   end
 

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Glossarist::LocalizedConcept do
         terms: [{"some" => "designation"}, {"another" => "designation"}],
         examples: ["ex. one"],
         notes: ["note one"],
-        authoritative_source: [{"source" => "reference"}],
+        sources: [{"source" => "reference"}],
       })
 
       retval = subject.to_h
@@ -149,7 +149,7 @@ RSpec.describe Glossarist::LocalizedConcept do
       expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
       expect(retval.definition).to eq("Example Definition")
       expect(retval.terms.dig(0, "designation")).to eq("Example Designation")
-      expect(retval.authoritative_source).to eq([{"Example Source" => "Reference"}])
+      expect(retval.sources).to eq([{"Example Source" => "Reference"}])
     end
   end
 end


### PR DESCRIPTION
Rename `LocalizedConcept#authoritative_source` to `#sources`, as the latter is shorter, and is a plural world.  Previous name becomes an alias for backwards compatibility.