### PR TITLE
Introduce Designation models

### DIFF
--- a/lib/glossarist.rb
+++ b/lib/glossarist.rb
@@ -10,6 +10,7 @@ require_relative "glossarist/version"
 require_relative "glossarist/model"
 require_relative "glossarist/concept"
 require_relative "glossarist/collection"
+require_relative "glossarist/designations"
 require_relative "glossarist/localized_concept"
 
 module Glossarist

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -70,7 +70,7 @@ module Glossarist
 
     def default_designation
       localized = localization("eng") || localizations.values.first
-      localized&.terms&.dig(0, "designation")
+      localized&.terms&.first&.designation
     end
 
     def related_concepts

--- a/lib/glossarist/designations.rb
+++ b/lib/glossarist/designations.rb
@@ -76,7 +76,7 @@ module Glossarist
       Expression => "expression",
       Symbol => "symbol",
     }
-    .yield_self { |h| h.merge(h.invert) }
+    .tap { |h| h.merge!(h.invert) }
     .freeze
   end
 end

--- a/lib/glossarist/designations.rb
+++ b/lib/glossarist/designations.rb
@@ -12,6 +12,27 @@ module Glossarist
 
       attr_accessor :normative_status
       attr_accessor :geographical_area
+
+      def self.from_h(hash)
+        type = hash["type"]
+
+        if type.nil? || /\w/ !~ type
+          raise ArgumentError, "designation type is missing"
+        end
+
+        designation_subclass = SERIALIZED_TYPES[type]
+
+        if self == Base
+          # called on Base class, delegate it to proper subclass
+          SERIALIZED_TYPES[type].from_h(hash)
+        else
+          # called on subclass, instantiate object
+          unless SERIALIZED_TYPES[self] == type
+            raise ArgumentError, "unexpected designation type: #{type}"
+          end
+          super(hash.reject { |k, _| k == "type" })
+        end
+      end
     end
 
     class Expression < Base
@@ -20,10 +41,42 @@ module Glossarist
       attr_accessor :plurality
       attr_accessor :prefix
       attr_accessor :usage_info
+
+      def to_h
+        {
+          "type" => "expression",
+          "prefix" => prefix,
+          "normative_status" => normative_status,
+          "usage_info" => usage_info,
+          "designation" => designation,
+          "part_of_speech" => part_of_speech,
+          "geographical_area" => geographical_area,
+          "gender" => gender,
+          "plurality" => plurality,
+        }.compact
+      end
     end
 
     class Symbol < Base
       attr_accessor :international
+
+      def to_h
+        {
+          "type" => "symbol",
+          "normative_status" => normative_status,
+          "geographical_area" => geographical_area,
+          "designation" => designation,
+          "international" => international,
+        }.compact
+      end
     end
+
+    # Bi-directional class-to-string mapping for STI-like serialization.
+    SERIALIZED_TYPES = {
+      Expression => "expression",
+      Symbol => "symbol",
+    }
+    .yield_self { |h| h.merge(h.invert) }
+    .freeze
   end
 end

--- a/lib/glossarist/designations.rb
+++ b/lib/glossarist/designations.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# (c) Copyright 2021 Ribose Inc.
+#
+
+module Glossarist
+  module Designations
+    class Base < Model
+      # @note This is not entirely aligned with agreed schema and may be
+      #   changed.
+      attr_accessor :designation
+
+      attr_accessor :normative_status
+      attr_accessor :geographical_area
+    end
+
+    class Expression < Base
+      attr_accessor :gender
+      attr_accessor :part_of_speech
+      attr_accessor :plurality
+      attr_accessor :prefix
+      attr_accessor :usage_info
+    end
+
+    class Symbol < Base
+      attr_accessor :international
+    end
+  end
+end

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -16,9 +16,7 @@ module Glossarist
 
     # Concept designations.
     # @todo Alias +terms+ exists only for legacy reasons and will be removed.
-    # @todo Right now accepts hashes for legacy reasons, but they will be
-    #   replaced with dedicated classes.
-    # @return [Array<Hash>]
+    # @return [Array<Designations::Base>]
     attr_accessor :designations
     alias :terms :designations
     alias :terms= :designations=
@@ -84,7 +82,7 @@ module Glossarist
     def to_h # rubocop:disable Metrics/MethodLength
       {
         "id" => id,
-        "terms" => terms,
+        "terms" => (terms&.map(&:to_h) || []),
         "definition" => definition,
         "language_code" => language_code,
         "notes" => notes,
@@ -98,6 +96,11 @@ module Glossarist
         "review_decision_date" => review_decision_date,
         "review_decision_event" => review_decision_event,
       }.compact
+    end
+
+    def self.from_h(hash)
+      terms = hash["terms"]&.map { |h| Designations::Base.from_h(h) } || []
+      super(hash.merge({"terms" => terms}))
     end
 
     # @deprecated For legacy reasons only.

--- a/spec/features/serialization_spec.rb
+++ b/spec/features/serialization_spec.rb
@@ -15,15 +15,15 @@ RSpec.describe "Serialization and deserialization" do
       rook.l10n("eng"), rook.l10n("pol"),
     ]).to all be_kind_of(Glossarist::LocalizedConcept)
 
-    expect(king.l10n("eng").designations.first["designation"]).to eq("King")
-    expect(queen.l10n("eng").designations.first["designation"]).to eq("Queen")
-    expect(rook.l10n("eng").designations.first["designation"]).to eq("Rook")
+    expect(king.l10n("eng").designations.first.designation).to eq("King")
+    expect(queen.l10n("eng").designations.first.designation).to eq("Queen")
+    expect(rook.l10n("eng").designations.first.designation).to eq("Rook")
 
-    expect(king.l10n("eng").designations.last["designation"])
+    expect(king.l10n("eng").designations.last.designation)
       .to match(/\p{Symbol}/)
-    expect(queen.l10n("eng").designations.last["designation"])
+    expect(queen.l10n("eng").designations.last.designation)
       .to match(/\p{Symbol}/)
-    expect(rook.l10n("eng").designations.last["designation"])
+    expect(rook.l10n("eng").designations.last.designation)
       .to match(/\p{Symbol}/)
 
     expect(king.l10n("eng").sources.dig(0, "ref", "source")).to eq("Wikipedia")

--- a/spec/unit/concept_spec.rb
+++ b/spec/unit/concept_spec.rb
@@ -28,19 +28,19 @@ RSpec.describe Glossarist::Concept do
 
       object.localizations["ara"] = double(
         terms: [
-          {"designation" => "in Arabic"}, {"designation" => "in Arabic 2"}
+          double(designation: "in Arabic"), double(designation: "in Arabic 2")
         ]
       )
 
       object.localizations["eng"] = double(
         terms: [
-          {"designation" => "in English"}, {"designation" => "in English 2"}
+          double(designation: "in English"), double(designation: "in English 2")
         ]
       )
 
       object.localizations["deu"] = double(
         terms: [
-          {"designation" => "in German"}, {"designation" => "in German 2"}
+          double(designation: "in German"), double(designation: "in German 2")
         ]
       )
 
@@ -52,13 +52,13 @@ RSpec.describe Glossarist::Concept do
 
       object.localizations["ara"] = double(
         terms: [
-          {"designation" => "in Arabic"}, {"designation" => "in Arabic 2"}
+          double(designation: "in Arabic"), double(designation: "in Arabic 2")
         ]
       )
 
       object.localizations["deu"] = double(
         terms: [
-          {"designation" => "in German"}, {"designation" => "in German 2"}
+          double(designation: "in German"), double(designation: "in German 2")
         ]
       )
 

--- a/spec/unit/designations_spec.rb
+++ b/spec/unit/designations_spec.rb
@@ -32,6 +32,46 @@ RSpec.describe Glossarist::Designations::Expression do
     expect { subject.part_of_speech = "adjective" }
       .to change { subject.part_of_speech }.to("adjective")
   end
+
+  describe "#to_h" do
+    it "dumps designation to a hash" do
+      attrs.replace({
+        designation: "Example designation",
+        normative_status: "preferred",
+        geographical_area: "somewhere",
+        gender: "masculine",
+        part_of_speech: "some part",
+        plurality: "singular",
+        usage_info: "science",
+      })
+
+      retval = subject.to_h
+      expect(retval).to be_kind_of(Hash)
+      expect(retval["type"]).to eq("expression")
+      expect(retval["designation"]).to eq("Example designation")
+      expect(retval["normative_status"]).to eq("preferred")
+      expect(retval["geographical_area"]).to eq("somewhere")
+      expect(retval["gender"]).to eq("masculine")
+      expect(retval["part_of_speech"]).to eq("some part")
+      expect(retval["plurality"]).to eq("singular")
+      expect(retval["usage_info"]).to eq("science")
+    end
+  end
+
+  describe "::from_h" do
+    it "loads localized concept definition from a hash" do
+      src = {
+        "type" => "expression",
+        "designation" => "Example Designation",
+        "normative_status" => "preferred",
+      }
+
+      retval = described_class.from_h(src)
+      expect(retval).to be_kind_of(Glossarist::Designations::Expression)
+      expect(retval.designation).to eq("Example Designation")
+      expect(retval.normative_status).to eq("preferred")
+    end
+  end
 end
 
 RSpec.describe Glossarist::Designations::Symbol do
@@ -47,5 +87,39 @@ RSpec.describe Glossarist::Designations::Symbol do
   it "accepts strings as normative statuses" do
     expect { subject.normative_status = "admitted" }
       .to change { subject.normative_status }.to("admitted")
+  end
+
+  describe "#to_h" do
+    it "dumps designation to a hash" do
+      attrs.replace({
+        designation: "X",
+        normative_status: "preferred",
+        geographical_area: "somewhere",
+        international: true,
+      })
+
+      retval = subject.to_h
+      expect(retval).to be_kind_of(Hash)
+      expect(retval["type"]).to eq("symbol")
+      expect(retval["designation"]).to eq("X")
+      expect(retval["normative_status"]).to eq("preferred")
+      expect(retval["geographical_area"]).to eq("somewhere")
+      expect(retval["international"]).to be(true)
+    end
+  end
+
+  describe "::from_h" do
+    it "loads localized concept definition from a hash" do
+      src = {
+        "type" => "symbol",
+        "designation" => "Example Symbol",
+        "normative_status" => "preferred",
+      }
+
+      retval = described_class.from_h(src)
+      expect(retval).to be_kind_of(Glossarist::Designations::Symbol)
+      expect(retval.designation).to eq("Example Symbol")
+      expect(retval.normative_status).to eq("preferred")
+    end
   end
 end

--- a/spec/unit/designations_spec.rb
+++ b/spec/unit/designations_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# (c) Copyright 2021 Ribose Inc.
+#
+
+RSpec.describe Glossarist::Designations::Expression do
+  subject { described_class.new attrs }
+
+  let(:attrs) { { designation: "equality", normative_status: :preferred } }
+
+  it "accepts strings as designations" do
+    expect { subject.designation = "new one" }
+      .to change { subject.designation }.to("new one")
+  end
+
+  it "accepts strings as normative statuses" do
+    expect { subject.normative_status = "admitted" }
+      .to change { subject.normative_status }.to("admitted")
+  end
+
+  it "accepts strings as plurality values" do
+    expect { subject.plurality = "plural" }
+      .to change { subject.plurality }.to("plural")
+  end
+
+  it "accepts strings as genders" do
+    expect { subject.gender = "m" }
+      .to change { subject.gender }.to("m")
+  end
+
+  it "accepts strings as parts of speech" do
+    expect { subject.part_of_speech = "adjective" }
+      .to change { subject.part_of_speech }.to("adjective")
+  end
+end
+
+RSpec.describe Glossarist::Designations::Symbol do
+  subject { described_class.new attrs }
+
+  let(:attrs) { { designation: "sym", normative_status: :preferred } }
+
+  it "accepts strings as designations" do
+    expect { subject.designation = "new one" }
+      .to change { subject.designation }.to("new one")
+  end
+
+  it "accepts strings as normative statuses" do
+    expect { subject.normative_status = "admitted" }
+      .to change { subject.normative_status }.to("admitted")
+  end
+end

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -106,10 +106,12 @@ RSpec.describe Glossarist::LocalizedConcept do
 
   describe "#to_h" do
     it "dumps localized concept definition to a hash" do
+      term1 = double(to_h: {"some" => "designation"})
+      term2 = double(to_h: {"another" => "designation"})
       attrs.replace({
         id: "123",
         language_code: "lang",
-        terms: [{"some" => "designation"}, {"another" => "designation"}],
+        terms: [term1, term2],
         examples: ["ex. one"],
         notes: ["note one"],
         sources: [{"source" => "reference"}],
@@ -145,10 +147,17 @@ RSpec.describe Glossarist::LocalizedConcept do
         ],
       }
 
+      expr_dbl = double("expression")
+
+      expect(Glossarist::Designations::Base)
+        .to receive(:from_h)
+        .with(src["terms"][0])
+        .and_return(expr_dbl)
+
       retval = described_class.from_h(src)
       expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
       expect(retval.definition).to eq("Example Definition")
-      expect(retval.terms.dig(0, "designation")).to eq("Example Designation")
+      expect(retval.terms).to eq([expr_dbl])
       expect(retval.sources).to eq([{"Example Source" => "Reference"}])
     end
   end


### PR DESCRIPTION
Introduce brand new models for representing designations:

- `Glossarist::Designations::Expression`
- `Glossarist::Designations::Symbol`