### PR TITLE
Introduce Ref model

### DIFF
--- a/lib/glossarist.rb
+++ b/lib/glossarist.rb
@@ -12,6 +12,7 @@ require_relative "glossarist/concept"
 require_relative "glossarist/collection"
 require_relative "glossarist/designations"
 require_relative "glossarist/localized_concept"
+require_relative "glossarist/ref"
 
 module Glossarist
   class Error < StandardError; end

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -32,11 +32,10 @@ module Glossarist
     # @return [String]
     attr_accessor :definition
 
-    # @todo Right now accepts hashes for legacy reasons, but they will be
-    #   replaced with dedicated classes.
+    # List of authorative sources.
     # @todo Alias +authoritative_source+ exists for legacy reasons and may be
     #   removed.
-    # @return [Array<Hash>]
+    # @return [Array<Ref>]
     attr_accessor :sources
     alias :authoritative_source :sources
     alias :authoritative_source= :sources=
@@ -89,7 +88,7 @@ module Glossarist
         "examples" => examples,
         "entry_status" => entry_status,
         "classification" => classification,
-        "authoritative_source" => (sources if sources&.any?),
+        "authoritative_source" => sources&.map(&:to_h),
         "date_accepted" => date_accepted,
         "date_amended" => date_amended,
         "review_date" => review_date,
@@ -100,7 +99,8 @@ module Glossarist
 
     def self.from_h(hash)
       terms = hash["terms"]&.map { |h| Designations::Base.from_h(h) } || []
-      super(hash.merge({"terms" => terms}))
+      sources = hash["authoritative_source"]&.map { |h| Ref.from_h(h) }
+      super(hash.merge({"terms" => terms, "sources" => sources}))
     end
 
     # @deprecated For legacy reasons only.

--- a/lib/glossarist/ref.rb
+++ b/lib/glossarist/ref.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# (c) Copyright 2021 Ribose Inc.
+#
+
+module Glossarist
+  class Ref < Model
+    # Unstructured (plain text) reference.
+    # @return [String]
+    attr_accessor :text
+
+    # Source in structured reference.
+    # @return [String]
+    attr_accessor :source
+
+    # Document ID in structured reference.
+    # @return [String]
+    attr_accessor :id
+
+    # Document version in structured reference.
+    # @return [String]
+    attr_accessor :version
+
+    # @return [String]
+    # Referred clause of the document.
+    attr_accessor :clause
+
+    # Link to document.
+    # @return [String]
+    attr_accessor :link
+
+    # @return [String]
+    # @todo Pending documentation.
+    attr_accessor :status
+
+    # @return [String]
+    # @todo Pending documentation.
+    attr_accessor :modification
+
+    # Original ref text before parsing.
+    # @return [String]
+    # @note This attribute is likely to be removed or reworked in future.
+    #   It is arguably not relevant to Glossarist itself.
+    attr_accessor :original
+  end
+end

--- a/lib/glossarist/ref.rb
+++ b/lib/glossarist/ref.rb
@@ -42,5 +42,17 @@ module Glossarist
     # @note This attribute is likely to be removed or reworked in future.
     #   It is arguably not relevant to Glossarist itself.
     attr_accessor :original
+
+    # Whether it is a plain text ref.
+    # @return [Boolean]
+    def plain?
+      (source && id && version).nil?
+    end
+
+    # Whether it is a structured ref.
+    # @return [Boolean]
+    def structured?
+      !plain?
+    end
   end
 end

--- a/lib/glossarist/ref.rb
+++ b/lib/glossarist/ref.rb
@@ -54,5 +54,42 @@ module Glossarist
     def structured?
       !plain?
     end
+
+    def to_h
+      {
+        "ref" => ref_to_h,
+        "clause" => clause,
+        "link" => link,
+        "relationship" => relationship_to_h,
+        "original" => original,
+      }.compact
+    end
+
+    def self.from_h(hash)
+      hash = hash.dup
+
+      ref_val = hash.delete("ref")
+      rel_val = hash.delete("relationship")
+      hash.merge!(Hash === ref_val ? ref_val : {"text" => ref_val})
+      hash["status"] = rel_val&.fetch("type")
+      hash["modification"] = rel_val&.fetch("modification")
+      hash.compact!
+
+      super(hash)
+    end
+
+    private
+
+    def ref_to_h
+      if structured?
+        { "source" => source, "id" => id, "version" => version }.compact
+      else
+        text
+      end
+    end
+
+    def relationship_to_h
+      status && { "type" => status, "modification" => modification }.compact
+    end
   end
 end

--- a/spec/features/serialization_spec.rb
+++ b/spec/features/serialization_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe "Serialization and deserialization" do
     expect(rook.l10n("eng").designations.last.designation)
       .to match(/\p{Symbol}/)
 
-    expect(king.l10n("eng").sources.dig(0, "ref", "source")).to eq("Wikipedia")
-    expect(king.l10n("eng").sources.dig(0, "ref", "id")).to eq("King (chess)")
-    expect(king.l10n("eng").sources.dig(0, "link")).to start_with("https")
+    expect(king.l10n("eng").sources[0]).to be_structured
+    expect(king.l10n("eng").sources[0].source).to eq("Wikipedia")
+    expect(king.l10n("eng").sources[0].id).to eq("King (chess)")
+    expect(king.l10n("eng").sources[0].link).to start_with("https")
 
     expect(king.l10n("eng").superseded_concepts.size).to eq(1)
     expect(queen.l10n("eng").superseded_concepts.size).to eq(0)

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -108,13 +108,14 @@ RSpec.describe Glossarist::LocalizedConcept do
     it "dumps localized concept definition to a hash" do
       term1 = double(to_h: {"some" => "designation"})
       term2 = double(to_h: {"another" => "designation"})
+      source = double(to_h: {"source" => "reference"})
       attrs.replace({
         id: "123",
         language_code: "lang",
         terms: [term1, term2],
         examples: ["ex. one"],
         notes: ["note one"],
-        sources: [{"source" => "reference"}],
+        sources: [source],
       })
 
       retval = subject.to_h
@@ -148,17 +149,23 @@ RSpec.describe Glossarist::LocalizedConcept do
       }
 
       expr_dbl = double("expression")
+      source_dbl = double("source")
 
       expect(Glossarist::Designations::Base)
         .to receive(:from_h)
         .with(src["terms"][0])
         .and_return(expr_dbl)
 
+      expect(Glossarist::Ref)
+        .to receive(:from_h)
+        .with({"Example Source" => "Reference"})
+        .and_return(source_dbl)
+
       retval = described_class.from_h(src)
       expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
       expect(retval.definition).to eq("Example Definition")
       expect(retval.terms).to eq([expr_dbl])
-      expect(retval.sources).to eq([{"Example Source" => "Reference"}])
+      expect(retval.sources).to eq([source_dbl])
     end
   end
 end

--- a/spec/unit/ref_spec.rb
+++ b/spec/unit/ref_spec.rb
@@ -52,4 +52,100 @@ RSpec.describe Glossarist::Ref do
     expect { subject.original = "new one" }
       .to change { subject.original }.to("new one")
   end
+
+  describe "#to_h" do
+    it "dumps plain text ref to a hash" do
+      attrs.replace({
+        text: "Example ref",
+        clause: "12.3",
+        link: "https://example.com",
+        status: "modified",
+        modification: "something changed",
+        original: "original ref text",
+      })
+
+      retval = subject.to_h
+      expect(retval).to be_kind_of(Hash)
+      expect(retval["ref"]).to eq("Example ref")
+      expect(retval["clause"]).to eq("12.3")
+      expect(retval["link"]).to eq("https://example.com")
+      expect(retval["relationship"]["type"]).to eq("modified")
+      expect(retval["relationship"]["modification"]).to eq("something changed")
+      expect(retval["original"]).to eq("original ref text")
+    end
+
+    it "dumps structured ref to a hash" do
+      attrs.replace({
+        source: "Example source",
+        id: "12345",
+        version: "2020",
+        clause: "12.3",
+        link: "https://example.com",
+        status: "modified",
+        modification: "something changed",
+        original: "original ref text",
+      })
+
+      retval = subject.to_h
+      expect(retval).to be_kind_of(Hash)
+      expect(retval["ref"]["source"]).to eq("Example source")
+      expect(retval["ref"]["id"]).to eq("12345")
+      expect(retval["ref"]["version"]).to eq("2020")
+      expect(retval["clause"]).to eq("12.3")
+      expect(retval["link"]).to eq("https://example.com")
+      expect(retval["relationship"]["type"]).to eq("modified")
+      expect(retval["relationship"]["modification"]).to eq("something changed")
+      expect(retval["original"]).to eq("original ref text")
+    end
+  end
+
+  describe "::from_h" do
+    it "loads plain text ref from a hash" do
+      src = {
+        "ref" => "Some Ref",
+        "clause" => "12.3",
+        "link" => "https://example.com",
+        "original" => "original ref text",
+        "relationship" => {
+          "type" => "modified",
+          "modification" => "something changed",
+        }
+      }
+
+      retval = described_class.from_h(src)
+      expect(retval).to be_kind_of(Glossarist::Ref)
+      expect(retval.text).to eq("Some Ref")
+      expect(retval.clause).to eq("12.3")
+      expect(retval.link).to eq("https://example.com")
+      expect(retval.status).to eq("modified")
+      expect(retval.modification).to eq("something changed")
+    end
+
+    it "loads structured ref from a hash" do
+      src = {
+        "ref" => {
+          "source" => "Example source",
+          "id" => "12345",
+          "version" => "2020",
+        },
+        "clause" => "12.3",
+        "link" => "https://example.com",
+        "original" => "original ref text",
+        "relationship" => {
+          "type" => "modified",
+          "modification" => "something changed",
+        }
+      }
+
+      retval = described_class.from_h(src)
+      expect(retval).to be_kind_of(Glossarist::Ref)
+      expect(retval.source).to eq("Example source")
+      expect(retval.id).to eq("12345")
+      expect(retval.version).to eq("2020")
+      expect(retval.clause).to eq("12.3")
+      expect(retval.link).to eq("https://example.com")
+      expect(retval.status).to eq("modified")
+      expect(retval.modification).to eq("something changed")
+    end
+  end
 end

--- a/spec/unit/ref_spec.rb
+++ b/spec/unit/ref_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# (c) Copyright 2021 Ribose Inc.
+#
+
+RSpec.describe Glossarist::Ref do
+  subject { described_class.new attrs }
+
+  let(:attrs) { { text: "some ref" } }
+
+  it "accepts strings as text" do
+    expect { subject.text = "new one" }
+      .to change { subject.text }.to("new one")
+  end
+
+  it "accepts strings as source" do
+    expect { subject.source = "new one" }
+      .to change { subject.source }.to("new one")
+  end
+
+  it "accepts strings as id" do
+    expect { subject.id = "new one" }
+      .to change { subject.id }.to("new one")
+  end
+
+  it "accepts strings as version" do
+    expect { subject.version = "new one" }
+      .to change { subject.version }.to("new one")
+  end
+
+  it "accepts strings as clause" do
+    expect { subject.clause = "new one" }
+      .to change { subject.clause }.to("new one")
+  end
+
+  it "accepts strings as link" do
+    expect { subject.link = "new one" }
+      .to change { subject.link }.to("new one")
+  end
+
+  it "accepts strings as status" do
+    expect { subject.status = "new one" }
+      .to change { subject.status }.to("new one")
+  end
+
+  it "accepts strings as modification" do
+    expect { subject.modification = "new one" }
+      .to change { subject.modification }.to("new one")
+  end
+
+  it "accepts strings as original" do
+    expect { subject.original = "new one" }
+      .to change { subject.original }.to("new one")
+  end
+end


### PR DESCRIPTION
Introduce a brand new `Glossarist::Ref` model for representing references to other documents, and use it to represent authoritative sources (`LocalizedConcept#sources`).