### PR TITLE
Convert normative status to enum

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,13 @@ concept_source:
     - authoritative
     - lineage
 
+designation:
+  base:
+    normative_status:
+      - preferred
+      - deprecated
+      - admitted
+
 related_concept:
   type:
     - deprecates

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -102,7 +102,7 @@ module Glossarist
       # List of related concepts of the specified type.
       # @return [Array<RelatedConcept>]
       define_method("#{type}_concepts") do
-        related&.select { |concept| concept.type == type.to_sym } || []
+        related&.select { |concept| concept.type == type.to_s } || []
       end
     end
   end

--- a/lib/glossarist/designation/base.rb
+++ b/lib/glossarist/designation/base.rb
@@ -3,12 +3,21 @@
 module Glossarist
   module Designation
     class Base < Model
+      include Glossarist::Utilities::Enum
+
       # @note This is not entirely aligned with agreed schema and may be
       #   changed.
       attr_accessor :designation
 
-      attr_accessor :normative_status
       attr_accessor :geographical_area
+
+      NORMATIVE_STATUSES = %i[
+        preferred
+        deprecated
+        admitted
+      ].freeze
+
+      register_enum :normative_status, NORMATIVE_STATUSES
 
       def self.from_h(hash)
         type = hash["type"]

--- a/lib/glossarist/designation/base.rb
+++ b/lib/glossarist/designation/base.rb
@@ -10,14 +10,7 @@ module Glossarist
       attr_accessor :designation
 
       attr_accessor :geographical_area
-
-      NORMATIVE_STATUSES = %i[
-        preferred
-        deprecated
-        admitted
-      ].freeze
-
-      register_enum :normative_status, NORMATIVE_STATUSES
+      register_enum :normative_status, Glossarist::GlossaryDefinition::DESIGNATION_BASE_NORMATIVE_STATUSES
 
       def self.from_h(hash)
         type = hash["type"]

--- a/lib/glossarist/glossary_definition.rb
+++ b/lib/glossarist/glossary_definition.rb
@@ -19,5 +19,7 @@ module Glossarist
     GRAMMAR_INFO_GENDERS = config.dig("grammar_info", "gender").freeze
 
     GRAMMAR_INFO_NUMBERS = config.dig("grammar_info", "number").freeze
+
+    DESIGNATION_BASE_NORMATIVE_STATUSES = config.dig("designation", "base", "normative_status").freeze
   end
 end

--- a/lib/glossarist/utilities/enum.rb
+++ b/lib/glossarist/utilities/enum.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "enum/enum_collection"
 require_relative "enum/class_methods"
 require_relative "enum/instance_methods"
 

--- a/lib/glossarist/utilities/enum/class_methods.rb
+++ b/lib/glossarist/utilities/enum/class_methods.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "set"
+
 module Glossarist
   module Utilities
     module Enum

--- a/lib/glossarist/utilities/enum/enum_collection.rb
+++ b/lib/glossarist/utilities/enum/enum_collection.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Glossarist
+  module Utilities
+    module Enum
+      class EnumCollection
+        include Enumerable
+
+        Enumerator = Struct.new(:registered_values, :options, keyword_init: true)
+
+        def initialize
+          @collection = {}
+        end
+
+        def add(name, values, options = {})
+          @collection[name] = { registered_values: values, options: options }
+        end
+
+        def each(&block)
+          if block_given?
+            @collection.each do |object|
+              block.call(object)
+            end
+          else
+            enum_for(:each)
+          end
+        end
+
+        def registered_enums
+          @collection&.keys || []
+        end
+
+        def valid_types(name)
+          @collection[name][:registered_values]
+        end
+
+        def type_options(name)
+          @collection[name][:options]
+        end
+
+        def [](name)
+          @collection[name]
+        end
+      end
+    end
+  end
+end

--- a/lib/glossarist/utilities/enum/enum_collection.rb
+++ b/lib/glossarist/utilities/enum/enum_collection.rb
@@ -6,8 +6,6 @@ module Glossarist
       class EnumCollection
         include Enumerable
 
-        Enumerator = Struct.new(:registered_values, :options, keyword_init: true)
-
         def initialize
           @collection = {}
         end

--- a/lib/glossarist/utilities/enum/instance_methods.rb
+++ b/lib/glossarist/utilities/enum/instance_methods.rb
@@ -5,13 +5,7 @@ module Glossarist
     module Enum
       module InstanceMethods
         def selected_type
-          if @selected_type.nil?
-            @selected_type = {}
-
-            self.class.registered_enums.each do |type|
-              @selected_type[type] = []
-            end
-          end
+          initialize_selected_type if @selected_type.nil?
 
           @selected_type
         end
@@ -45,6 +39,14 @@ module Glossarist
               Glossarist::InvalidTypeError,
               "`#{value}` is not a valid #{type_name}. Supported #{type_name} are #{self.class.enums[type_name][:registered_values].to_a.join(", ")}"
             )
+          end
+        end
+
+        def initialize_selected_type
+          @selected_type = {}
+
+          self.class.registered_enums.each do |type|
+            @selected_type[type] = []
           end
         end
       end

--- a/spec/support/shared_examples/enum.rb
+++ b/spec/support/shared_examples/enum.rb
@@ -23,7 +23,7 @@ RSpec.shared_examples "an Enum" do
 
   described_class.registered_enums.each do |type|
     describe "##{type}=" do
-      let!(:valid_type) { described_class.enums[type][:registered_values].first }
+      let!(:valid_type) { described_class.enums[type][:registered_values].first&.to_s }
 
       context "when type is valid" do
         it "will set the type" do

--- a/spec/unit/concept_spec.rb
+++ b/spec/unit/concept_spec.rb
@@ -179,8 +179,8 @@ RSpec.describe Glossarist::Concept do
       expect(retval.l10n("eng")).to be(eng_dbl)
       expect(retval.l10n("deu")).to be(deu_dbl)
       expect(retval.sources.size).to eq(1)
-      expect(retval.sources.first.type).to eq(:authoritative)
-      expect(retval.sources.first.status).to eq(:identical)
+      expect(retval.sources.first.type).to eq("authoritative")
+      expect(retval.sources.first.status).to eq("identical")
       expect(retval.sources.first.origin).to eq("reference")
     end
   end

--- a/spec/unit/designation/grammar_info_spec.rb
+++ b/spec/unit/designation/grammar_info_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe Glossarist::Designation::GrammarInfo do
         "verb" => false,
         "adverb" => false,
         "noun" => false,
-        "gender" => %i[m],
-        "number" => %i[singular plural],
+        "gender" => %w[m],
+        "number" => %w[singular plural],
       }
 
       expect(grammar_info.to_h).to eq(expected_hash)

--- a/spec/unit/designations_spec.rb
+++ b/spec/unit/designations_spec.rb
@@ -20,12 +20,12 @@ RSpec.describe Glossarist::Designation::Expression do
 
   it "accepts strings as plurality values" do
     expect { subject.grammar_info.first.number = "plural" }
-      .to change { subject.grammar_info.first.number }.to([:plural])
+      .to change { subject.grammar_info.first.number }.to(["plural"])
   end
 
   it "accepts strings as genders" do
     expect { subject.grammar_info.first.gender = "m" }
-      .to change { subject.grammar_info.first.gender }.to([:m])
+      .to change { subject.grammar_info.first.gender }.to(["m"])
   end
 
   it "accepts strings as parts of speech" do
@@ -53,9 +53,9 @@ RSpec.describe Glossarist::Designation::Expression do
       expect(retval["designation"]).to eq("Example designation")
       expect(retval["normative_status"]).to eq("preferred")
       expect(retval["geographical_area"]).to eq("somewhere")
-      expect(retval["grammar_info"].first["gender"]).to eq([:m])
+      expect(retval["grammar_info"].first["gender"]).to eq(["m"])
       expect(retval["grammar_info"].first["adj"]).to eq(true)
-      expect(retval["grammar_info"].first["number"]).to eq([:singular])
+      expect(retval["grammar_info"].first["number"]).to eq(["singular"])
       expect(retval["usage_info"]).to eq("science")
     end
   end

--- a/spec/unit/detailed_definition_spec.rb
+++ b/spec/unit/detailed_definition_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe Glossarist::DetailedDefinition do
 
       expect(detailed_definition.sources.size).to eq(2)
       expect(detailed_definition.sources.first).to be_a(Glossarist::ConceptSource)
-      expect(detailed_definition.sources.first.type).to eq(:lineage)
-      expect(detailed_definition.sources.first.status).to eq(:identical)
+      expect(detailed_definition.sources.first.type).to eq("lineage")
+      expect(detailed_definition.sources.first.status).to eq("identical")
       expect(detailed_definition.sources.first.origin).to eq("url")
       expect(detailed_definition.sources.first.modification).to eq("some modification")
 

--- a/spec/unit/utilities/enum/class_methods_spec.rb
+++ b/spec/unit/utilities/enum/class_methods_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe Glossarist::Utilities::Enum::ClassMethods do
         }
       }
 
-      expect(subject.enums).to eq(expected_enums)
+      expect(subject.enums.registered_enums).to eq(expected_enums.keys)
+      expect(subject.enums[:status]).to eq(expected_enums[:status])
+      expect(subject.enums[:number]).to eq(expected_enums[:number])
     end
   end
 
@@ -89,20 +91,20 @@ RSpec.describe Glossarist::Utilities::Enum::ClassMethods do
     end
   end
 
-  describe ".add_check_method" do
+  describe ".register_check_method" do
     it "adds a <type?> method to class" do
       expect(subject.method_defined?(:male?)).to be(false)
 
-      subject.add_check_method(:foo, :male)
+      subject.register_check_method(:foo, :male)
       expect(subject.method_defined?(:male?)).to be(true)
     end
   end
 
-  describe ".add_set_method" do
+  describe ".register_set_method" do
     it "adds a <type=> method to class" do
       expect(subject.method_defined?(:baz=)).to be(false)
 
-      subject.add_set_method(:baz, :alpha)
+      subject.register_set_method(:baz, :alpha)
       expect(subject.method_defined?(:alpha=)).to be(true)
     end
   end


### PR DESCRIPTION
- Converted `normative_status` to enum
- Allow enum attributes to be inheritable

closes #39 