### PR TITLE
moving groups out of translations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -2,7 +2,7 @@
 
 == Commands
 
-generate_latex: Convert Concepts to Latex format
+`generate_latex`: Convert Concepts to Latex format
 
 === Usage:
   glossarist generate_latex p, --concepts-path=CONCEPTS_PATH

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -24,10 +24,6 @@ module Glossarist
     # @return [String]
     attr_accessor :classification
 
-    # Concept group
-    # @return [Array<String>]
-    attr_reader :group
-
     attr_accessor :review_date
     attr_accessor :review_decision_date
     attr_accessor :review_decision_event
@@ -36,10 +32,6 @@ module Glossarist
       @examples = []
 
       super
-    end
-
-    def group=(groups)
-      @group = groups.is_a?(Array) ? groups : [groups]
     end
 
     def to_h # rubocop:disable Metrics/MethodLength
@@ -52,7 +44,6 @@ module Glossarist
         "review_date" => review_date,
         "review_decision_date" => review_decision_date,
         "review_decision_event" => review_decision_event,
-        "group" => group,
       }.compact).merge(@extension_attributes)
     end
 

--- a/lib/glossarist/managed_concept.rb
+++ b/lib/glossarist/managed_concept.rb
@@ -21,6 +21,10 @@ module Glossarist
     # return [Array<LocalizedConcept>]
     attr_reader :localized_concepts
 
+    # Concept group
+    # @return [Array<String>]
+    attr_reader :groups
+
     # All localizations for this concept.
     #
     # Keys are language codes and values are instances of {LocalizedConcept}.
@@ -53,6 +57,12 @@ module Glossarist
       @dates = dates&.map { |d| ConceptDate.new(d) }
     end
 
+    def groups=(groups)
+      return unless groups
+
+      @groups = groups.is_a?(Array) ? groups : [groups]
+    end
+
     # Adds concept localization.
     # @param localized_concept [LocalizedConcept]
     def add_localization(localized_concept)
@@ -77,6 +87,7 @@ module Glossarist
         "term" => default_designation,
         "related" => related&.map(&:to_h),
         "dates" => dates&.empty? ? nil : dates&.map(&:to_h),
+        "groups" => groups,
       }.merge(localizations.transform_values(&:to_h)).compact
     end
 
@@ -102,6 +113,7 @@ module Glossarist
         status
         dates
         localized_concepts
+        groups
       ].compact
     end
 

--- a/spec/fixtures/chess_concepts/concept-chess-02-01.yaml
+++ b/spec/fixtures/chess_concepts/concept-chess-02-01.yaml
@@ -7,6 +7,9 @@ related:
     source: Chess rules
     id: chess-02-01
     version: some older definition
+groups:
+- chess-piece
+- king
 eng:
   id: chess-02-01
   terms:
@@ -39,9 +42,6 @@ eng:
     date: '2021-05-01T00:00:00+00:00'
   - type: amended
     date: '2021-05-01T00:00:00+00:00'
-  group:
-  - chess-piece
-  - king
 pol:
   id: chess-02-01
   terms:
@@ -62,6 +62,3 @@ pol:
     date: '2021-05-01T00:00:00+00:00'
   - type: amended
     date: '2021-05-01T00:00:00+00:00'
-  group:
-  - chess-piece
-  - king

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -50,22 +50,6 @@ RSpec.describe Glossarist::LocalizedConcept do
       .to change { subject.review_decision_event }.to("published")
   end
 
-  describe "#group" do
-    context "when string is given" do
-      it "should change it to array" do
-        expect { subject.group = "group-1" }
-          .to change { subject.group }.to(["group-1"])
-      end
-    end
-
-    context "when array is given" do
-      it "should assign it to group" do
-        expect { subject.group = ["group-1"] }
-          .to change { subject.group }.to(["group-1"])
-      end
-    end
-  end
-
   describe "#designations" do
     let(:expression) { double("expression designation") }
 

--- a/spec/unit/managed_concept_spec.rb
+++ b/spec/unit/managed_concept_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Glossarist::ManagedConcept do
           "date" => "2020-01-01",
         },
       ],
+
+      "groups" => [
+        "foo",
+        "bar"
+      ],
     }
   end
 
@@ -49,6 +54,22 @@ RSpec.describe Glossarist::ManagedConcept do
 
       expect(subject.dates.first.type).to eq("accepted")
       expect(subject.dates.first.date).to eq("2020-01-01")
+    end
+  end
+
+  describe "#groups" do
+    context "when string is given" do
+      it "should convert it to array and set the groups list for the concept" do
+        expect { subject.groups = "foobar" }
+          .to change { subject.groups }.to(["foobar"])
+      end
+    end
+
+    context "when array is given" do
+      it "sets the groups list for the concept" do
+        expect { subject.groups = ["general", "group"] }
+          .to change { subject.groups }.to(["general", "group"])
+      end
     end
   end
 


### PR DESCRIPTION
Moved the group outside of translations and into the concept as discussed here -> https://github.com/glossarist/glossarist-ruby/pull/60#issuecomment-1540220811