### PR TITLE
Update relaton version to 1.15

### DIFF
--- a/glossarist.gemspec
+++ b/glossarist.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "relaton", "~>1.14.0"
+  spec.add_dependency "relaton", "~> 1.15.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "pry", "~> 0.14.0"


### PR DESCRIPTION
Updated `relaton` version for https://github.com/metanorma/iso-10303-2/pull/284