### PR TITLE
feat: raise error on invalid concepts

### DIFF
--- a/lib/glossarist.rb
+++ b/lib/glossarist.rb
@@ -33,7 +33,10 @@ require_relative "glossarist/config"
 
 module Glossarist
   class Error < StandardError; end
+
   class InvalidTypeError < StandardError; end
+
+  class ParseError < StandardError; end
   # Your code goes here...
 
   def self.configure

--- a/lib/glossarist.rb
+++ b/lib/glossarist.rb
@@ -36,7 +36,20 @@ module Glossarist
 
   class InvalidTypeError < StandardError; end
 
-  class ParseError < StandardError; end
+  class ParseError < StandardError
+    attr_accessor :line, :filename
+
+    def initialize(filename:, line: nil)
+      @filename = filename
+      @line = line
+
+      super()
+    end
+
+    def to_s
+      "Unable to parse file: #{filename}, error on line: #{line}"
+    end
+  end
   # Your code goes here...
 
   def self.configure

--- a/lib/glossarist/collection.rb
+++ b/lib/glossarist/collection.rb
@@ -65,21 +65,25 @@ module Glossarist
       end
     end
 
-    private def load_concept_from_file(filename)
-      Concept.from_h(Psych.safe_load(File.read(filename)))
-    end
-
     # Writes all concepts to files.
     def save_concepts
       @index.each_value &method(:save_concept_to_file)
     end
 
-    private def save_concept_to_file(concept)
+    private
+
+    def load_concept_from_file(filename)
+      Concept.from_h(Psych.safe_load(File.read(filename)))
+    rescue Psych::SyntaxError
+      raise(Glossarist::ParseError, "Unable to parse file: #{filename}")
+    end
+
+    def save_concept_to_file(concept)
       filename = File.join(path, "concept-#{concept.id}.yaml")
       File.write(filename, Psych.dump(concept.to_h))
     end
 
-    private def concepts_glob
+    def concepts_glob
       File.join(path, "concept-*.{yaml,yml}")
     end
   end

--- a/lib/glossarist/collection.rb
+++ b/lib/glossarist/collection.rb
@@ -74,8 +74,8 @@ module Glossarist
 
     def load_concept_from_file(filename)
       Concept.from_h(Psych.safe_load(File.read(filename)))
-    rescue Psych::SyntaxError
-      raise(Glossarist::ParseError, "Unable to parse file: #{filename}")
+    rescue Psych::SyntaxError => e
+      raise Glossarist::ParseError.new(filename: filename, line: e.line)
     end
 
     def save_concept_to_file(concept)

--- a/lib/glossarist/concept_manager.rb
+++ b/lib/glossarist/concept_manager.rb
@@ -28,8 +28,8 @@ module Glossarist
 
     def load_concept_from_file(filename)
       ManagedConcept.new(Psych.safe_load(File.read(filename)))
-    rescue Psych::SyntaxError
-      raise(Glossarist::ParseError, "Unable to parse file: #{filename}")
+    rescue Psych::SyntaxError => e
+      raise Glossarist::ParseError.new(filename: filename, line: e.line)
     end
 
     def save_concept_to_file(concept)

--- a/lib/glossarist/concept_manager.rb
+++ b/lib/glossarist/concept_manager.rb
@@ -28,6 +28,8 @@ module Glossarist
 
     def load_concept_from_file(filename)
       ManagedConcept.new(Psych.safe_load(File.read(filename)))
+    rescue Psych::SyntaxError
+      raise(Glossarist::ParseError, "Unable to parse file: #{filename}")
     end
 
     def save_concept_to_file(concept)

--- a/spec/fixtures/invalid_concepts/concept-3.1.1.1.yaml
+++ b/spec/fixtures/invalid_concepts/concept-3.1.1.1.yaml
@@ -1,0 +1,26 @@
+---
+termid: 3.1.1.1
+term: entity
+eng:
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: entity
+  definition:
+  - content: concrete or abstract thing that exists, did exist, or can possibly exist,
+      including associations among these things
+  notes: []
+  examples:
+  - content: "{{person,Person}}, object, event, idea,
+      process, etc."
+  language_code: eng
+  entry_status: valid
+  sources:
+  - type: authoritative
+    origin:
+      ref: ISO/TS 14812:2022
+      clause: 3.1.1.1
+      link: https://www.iso.org/standard/79779.html
+
+  [.source]
+  <<ISO/TS 21308-4:2007>>

--- a/spec/fixtures/relaton_cache/iso/iso_ts_14812_2022.xml
+++ b/spec/fixtures/relaton_cache/iso/iso_ts_14812_2022.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.2.3">
-  <fetched>2023-04-27</fetched>
+  <fetched>2023-07-03</fetched>
   <title type="title-intro" format="text/plain" language="en" script="Latn">Intelligent transport systems</title>
   <title type="title-main" format="text/plain" language="en" script="Latn">Vocabulary</title>
   <title type="main" format="text/plain" language="en" script="Latn">Intelligent transport systems - Vocabulary</title>
@@ -7,10 +7,11 @@
   <title type="title-main" format="text/plain" language="fr" script="Latn">Vocabulaire</title>
   <title type="main" format="text/plain" language="fr" script="Latn">Systèmes de transport intelligents - Vocabulaire</title>
   <uri type="src">https://www.iso.org/standard/79779.html</uri>
-  <uri type="obp">https://www.iso.org/obp/ui/#!iso:std:79779:en</uri>
+  <uri type="obp">https://www.iso.org/obp/ui/en/#!iso:std:79779:en</uri>
   <uri type="rss">https://www.iso.org/contents/data/standard/07/97/79779.detail.rss</uri>
   <docidentifier type="ISO" primary="true">ISO/TS 14812:2022</docidentifier>
-  <docidentifier type="URN">urn:iso:std:iso:ts:14812:ed-1</docidentifier>
+  <docidentifier type="iso-reference">ISO 14812:2022(E)</docidentifier>
+  <docidentifier type="URN">urn:iso:std:iso:ts:14812:stage-90.92:ed-1</docidentifier>
   <docnumber>14812</docnumber>
   <date type="published">
     <on>2022-04</on>

--- a/spec/unit/managed_concept_collection_spec.rb
+++ b/spec/unit/managed_concept_collection_spec.rb
@@ -91,4 +91,32 @@ RSpec.describe Glossarist::ManagedConceptCollection do
       expect(managed_concept_collection.managed_concepts).to eq([managed_concept])
     end
   end
+
+  describe "#load_from_files" do
+    context "Invalid concepts" do
+      let(:invalid_concepts_path) { fixtures_path("invalid_concepts") }
+
+      it "will raise Glossarist::ParseError" do
+        expect do
+          managed_concept_collection.load_from_files(invalid_concepts_path)
+        end.to raise_error(Glossarist::ParseError)
+      end
+    end
+
+    context "Valid concepts" do
+      let(:valid_concepts_path) { fixtures_path("concept_collection") }
+
+      it "will not raise Glossarist::ParseError" do
+        expect do
+          managed_concept_collection.load_from_files(valid_concepts_path)
+        end.not_to raise_error(Glossarist::ParseError)
+      end
+
+      it "will not read concepts correctly from file" do
+        expect do
+          managed_concept_collection.load_from_files(valid_concepts_path)
+        end.to change { managed_concept_collection.count }.by(6)
+      end
+    end
+  end
 end

--- a/spec/unit/managed_concept_collection_spec.rb
+++ b/spec/unit/managed_concept_collection_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe Glossarist::ManagedConceptCollection do
         end.not_to raise_error(Glossarist::ParseError)
       end
 
-      it "will not read concepts correctly from file" do
+      it "will read concepts correctly from file" do
         expect do
           managed_concept_collection.load_from_files(valid_concepts_path)
         end.to change { managed_concept_collection.count }.by(6)


### PR DESCRIPTION
Override Psych error with a `Glossarist` error.

fixes #71 