### PR TITLE
feat: adding language_code and id validations

### DIFF
--- a/lib/glossarist.rb
+++ b/lib/glossarist.rb
@@ -30,28 +30,9 @@ require_relative "glossarist/non_verb_rep"
 require_relative "glossarist/collections"
 
 require_relative "glossarist/config"
+require_relative "glossarist/error"
 
 module Glossarist
-  class Error < StandardError; end
-
-  class InvalidTypeError < StandardError; end
-
-  class ParseError < StandardError
-    attr_accessor :line, :filename
-
-    def initialize(filename:, line: nil)
-      @filename = filename
-      @line = line
-
-      super()
-    end
-
-    def to_s
-      "Unable to parse file: #{filename}, error on line: #{line}"
-    end
-  end
-  # Your code goes here...
-
   def self.configure
     config = Glossarist::Config.instance
 

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -7,8 +7,7 @@ module Glossarist
   class Concept < Model
     # Concept ID.
     # @return [String]
-    attr_accessor :id
-    alias :termid= :id=
+    attr_reader :id
 
     # Concept designations.
     # @todo Alias +terms+ exists only for legacy reasons and will be removed.
@@ -53,6 +52,13 @@ module Glossarist
 
       super
     end
+
+    def id=(id)
+      raise(Glossarist::Error, "id must be a string") unless id.is_a?(String) || id.nil?
+
+      @id = id
+    end
+    alias :termid= :id=
 
     # List of authorative sources.
     # @todo Alias +authoritative_source+ exists for legacy reasons and may be
@@ -119,7 +125,7 @@ module Glossarist
     # rubocop:disable Metrics/AbcSize, Style/RescueModifier
     def self.from_h(hash)
       new.tap do |concept|
-        concept.id = hash.dig("termid")
+        concept.id = hash.dig("termid") || hash.dig("id")
         concept.sources = hash.dig("sources")
         concept.related = hash.dig("related")
         concept.definition = hash.dig("definition")

--- a/lib/glossarist/error.rb
+++ b/lib/glossarist/error.rb
@@ -1,0 +1,8 @@
+require_relative "error/invalid_type_error"
+require_relative "error/invalid_language_code_error"
+require_relative "error/parse_error"
+
+module Glossarist
+  class Error < StandardError
+  end
+end

--- a/lib/glossarist/error/invalid_language_code_error.rb
+++ b/lib/glossarist/error/invalid_language_code_error.rb
@@ -1,0 +1,15 @@
+module Glossarist
+  class InvalidLanguageCodeError < Error
+    attr_reader :code
+
+    def initialize(code:)
+      @code = code
+
+      super()
+    end
+
+    def to_s
+      "Invalid value for language_code: `#{code}`. It must be 3 characters long string."
+    end
+  end
+end

--- a/lib/glossarist/error/invalid_type_error.rb
+++ b/lib/glossarist/error/invalid_type_error.rb
@@ -1,0 +1,4 @@
+module Glossarist
+  class InvalidTypeError < Error
+  end
+end

--- a/lib/glossarist/error/parse_error.rb
+++ b/lib/glossarist/error/parse_error.rb
@@ -1,0 +1,16 @@
+module Glossarist
+  class ParseError < Error
+    attr_accessor :line, :filename
+
+    def initialize(filename:, line: nil)
+      @filename = filename
+      @line = line
+
+      super()
+    end
+
+    def to_s
+      "Unable to parse file: #{filename}, error on line: #{line}"
+    end
+  end
+end

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -8,7 +8,7 @@ module Glossarist
     # ISO 639-2 code for terminology.
     # @see https://www.loc.gov/standards/iso639-2/php/code_list.php code list
     # @return [String]
-    attr_accessor :language_code
+    attr_reader :language_code
 
     # Must be one of the following:
     # +notValid+, +valid+, +superseded+, +retired+.
@@ -32,6 +32,14 @@ module Glossarist
       @examples = []
 
       super
+    end
+
+    def language_code=(language_code)
+      if language_code.is_a?(String) && language_code.length == 3
+        @language_code = language_code
+      else
+        raise Glossarist::InvalidLanguageCodeError.new(code: language_code)
+      end
     end
 
     def to_h # rubocop:disable Metrics/MethodLength

--- a/spec/fixtures/relaton_cache/iso/iso_ts_14812_2022.xml
+++ b/spec/fixtures/relaton_cache/iso/iso_ts_14812_2022.xml
@@ -1,5 +1,5 @@
 <bibdata type="standard" schema-version="v1.2.3">
-  <fetched>2023-07-03</fetched>
+  <fetched>2023-07-13</fetched>
   <title type="title-intro" format="text/plain" language="en" script="Latn">Intelligent transport systems</title>
   <title type="title-main" format="text/plain" language="en" script="Latn">Vocabulary</title>
   <title type="main" format="text/plain" language="en" script="Latn">Intelligent transport systems - Vocabulary</title>

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -13,9 +13,19 @@ RSpec.describe Glossarist::LocalizedConcept do
       .to change { subject.id }.to("456")
   end
 
+  it "raises error if id is not a `String`" do
+    expect { subject.id = 1234 }
+      .to raise_error(Glossarist::Error, "id must be a string")
+  end
+
   it "accepts strings as language codes" do
     expect { subject.language_code = "deu" }
       .to change { subject.language_code }.to("deu")
+  end
+
+  it "raises error if language_code is not 3 characters long" do
+    expect { subject.language_code = "urdu" }
+      .to raise_error(Glossarist::InvalidLanguageCodeError)
   end
 
   it "accepts strings as definitions" do
@@ -94,7 +104,7 @@ RSpec.describe Glossarist::LocalizedConcept do
       source = { "type" => "authoritative", "status" => "modified" }
       attrs.replace({
         id: "123",
-        language_code: "lang",
+        language_code: "eng",
         terms: [term1, term2],
         examples: ["ex. one"],
         notes: ["note one"],
@@ -103,7 +113,7 @@ RSpec.describe Glossarist::LocalizedConcept do
 
       retval = subject.to_h
       expect(retval).to be_kind_of(Hash)
-      expect(retval["language_code"]).to eq("lang")
+      expect(retval["language_code"]).to eq("eng")
       expect(retval["id"]).to eq("123")
       expect(retval["terms"]).to eq([term1, term2])
       expect(retval["examples"]).to eq([{ "content" => "ex. one"}])
@@ -133,6 +143,7 @@ RSpec.describe Glossarist::LocalizedConcept do
       retval = described_class.from_h(src)
 
       expect(retval).to be_kind_of(Glossarist::LocalizedConcept)
+      expect(retval.id).to eq("123-45")
       expect(retval.definition.size).to eq(1)
       expect(retval.definition.first.content).to eq("Example Definition")
       expect(retval.terms).to eq([])


### PR DESCRIPTION
Added `language_code` and `id` validations

fixes #69 
fixes #70 -> as mentioned in this comment https://github.com/glossarist/glossarist-ruby/issues/70#issuecomment-1622883606