### PR TITLE
fix: fetch_or_initialize return object

### DIFF
--- a/lib/glossarist/managed_concept_collection.rb
+++ b/lib/glossarist/managed_concept_collection.rb
@@ -64,6 +64,8 @@ module Glossarist
     def store(managed_concept)
       @managed_concepts[managed_concept.uuid] = managed_concept
       @managed_concepts_ids[managed_concept.id] = managed_concept.uuid if managed_concept.id
+
+      managed_concept
     end
 
     alias :<< :store

--- a/spec/unit/managed_concept_collection_spec.rb
+++ b/spec/unit/managed_concept_collection_spec.rb
@@ -74,11 +74,16 @@ RSpec.describe Glossarist::ManagedConceptCollection do
   end
 
   describe "#fetch_or_initialize" do
-    it "add and return a managed concept when not present" do
+    it "add a managed concept when not present" do
       expect{ managed_concept_collection.fetch_or_initialize("new") }
         .to change { managed_concept_collection.fetch("new") }
         .from(nil)
         .to(Glossarist::ManagedConcept)
+    end
+
+    it "add and return a managed concept when not present" do
+      expect(managed_concept_collection.fetch_or_initialize("new"))
+        .to be_an_instance_of(Glossarist::ManagedConcept)
     end
 
     it "returns a managed concept when present" do


### PR DESCRIPTION
There was a bug in `fetch_or_initialize` method inside `ManagedConceptCollection` class that it was returning a string in case the concept is initialized.

fixes metanorma/stepmod-utils#198