### PR TITLE
making managed_concept configureable

### DIFF
--- a/lib/glossarist/concept_manager.rb
+++ b/lib/glossarist/concept_manager.rb
@@ -36,7 +36,7 @@ module Glossarist
       concept_hash = Psych.safe_load(File.read(filename), permitted_classes: [Date, Time])
       concept_hash["uuid"] = concept_hash["id"] || File.basename(filename, ".*")
 
-      concept = ManagedConcept.new(concept_hash)
+      concept = Config.class_for(:managed_concept).new(concept_hash)
       concept.localized_concepts.each do |_lang, id|
         localized_concept = load_localized_concept(id)
         concept.add_l10n(localized_concept)

--- a/lib/glossarist/config.rb
+++ b/lib/glossarist/config.rb
@@ -8,6 +8,7 @@ module Glossarist
 
     DEFAULT_CLASSES = {
       localized_concept: Glossarist::LocalizedConcept,
+      managed_concept: Glossarist::ManagedConcept,
     }.freeze
 
     attr_reader :registered_classes

--- a/lib/glossarist/managed_concept_collection.rb
+++ b/lib/glossarist/managed_concept_collection.rb
@@ -17,7 +17,7 @@ module Glossarist
 
     def managed_concepts=(managed_concepts = [])
       managed_concepts.each do |managed_concept|
-        store(ManagedConcept.new(managed_concept))
+        store(Config.class_for(:managed_concept).new(managed_concept))
       end
 
       @managed_concepts.values
@@ -53,7 +53,7 @@ module Glossarist
     #    ManagedConcept ID
     # @return [ManagedConcept]
     def fetch_or_initialize(id)
-      fetch(id) or store(ManagedConcept.new(data: { id: id }))
+      fetch(id) or store(Config.class_for(:managed_concept).new(data: { id: id }))
     end
 
     # Adds concept to the collection. If collection contains a concept with

--- a/lib/glossarist/v1_reader.rb
+++ b/lib/glossarist/v1_reader.rb
@@ -10,7 +10,7 @@ module Glossarist
 
     def load_concept_from_file(filename)
       concept_hash = Psych.safe_load(File.read(filename), permitted_classes: [Date])
-      ManagedConcept.new(generate_v2_concept_hash(concept_hash))
+      Config.class_for(:managed_concept).new(generate_v2_concept_hash(concept_hash))
     end
 
     private

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -43,6 +43,13 @@ RSpec.describe Glossarist::Config do
         .to(Array)
     end
 
+    it "registers custom class for managed_concept" do
+      expect { described_class.register_class("managed_concept", Array) }
+        .to change { described_class.class_for("managed_concept") }
+        .from(Glossarist::ManagedConcept)
+        .to(Array)
+    end
+
     it "registers custom classes with symbol names" do
       expect { described_class.register_class(:foo, Array) }
         .to change { described_class.class_for(:foo) }


### PR DESCRIPTION
Adding support for making `Glossarist::ManagedConcept` configureable.