### PR TITLE
fixing model V1 reading and localized-concept path in V2

### DIFF
--- a/lib/glossarist/concept_manager.rb
+++ b/lib/glossarist/concept_manager.rb
@@ -5,6 +5,7 @@ module Glossarist
     # Path to concepts directory.
     # @return [String]
     attr_accessor :path
+    attr_accessor :localized_concepts_path
 
     # @param path [String]
     #   concepts directory path, either absolute or relative to CWD
@@ -60,8 +61,10 @@ module Glossarist
     end
 
     def save_concept_to_file(concept)
+      @localized_concepts_path ||= "localized_concept"
       concept_dir = File.join(path, "concept")
-      localized_concept_dir = File.join(path, "localized_concept")
+
+      localized_concept_dir = File.join(path, @localized_concepts_path)
 
       Dir.mkdir(concept_dir) unless Dir.exist?(concept_dir)
       Dir.mkdir(localized_concept_dir) unless Dir.exist?(localized_concept_dir)
@@ -86,7 +89,30 @@ module Glossarist
     end
 
     def localized_concept_path(id)
-      Dir.glob(File.join(path, "localized_concept", "#{id}.{yaml,yml}"))&.first
+      localized_concept_possible_dir = {
+        "localized_concept" => File.join(
+          path,
+          "localized_concept",
+          "#{id}.{yaml,yml}",
+        ),
+
+        "localized-concept" => File.join(
+          path,
+          "localized-concept",
+          "#{id}.{yaml,yml}",
+        ),
+      }
+
+      localized_concept_possible_dir.each do |dir_name, file_path|
+        actual_path = Dir.glob(file_path)&.first
+
+        if actual_path
+          @localized_concepts_path = dir_name
+          return actual_path
+        end
+      end
+
+      actual_path
     end
 
     def v1_collection?

--- a/lib/glossarist/v1_reader.rb
+++ b/lib/glossarist/v1_reader.rb
@@ -9,7 +9,7 @@ module Glossarist
     end
 
     def load_concept_from_file(filename)
-      concept_hash = Psych.safe_load(File.read(filename), permitted_classes: [Date])
+      concept_hash = Psych.safe_load(File.read(filename), permitted_classes: [Date, Time])
       Config.class_for(:managed_concept).new(generate_v2_concept_hash(concept_hash))
     end
 

--- a/spec/features/v2_serialization_spec.rb
+++ b/spec/features/v2_serialization_spec.rb
@@ -1,40 +1,83 @@
 RSpec.describe "Serialization and deserialization" do
-  let(:concept_folder) { "concept_collection_v2" }
-  let(:concept_files) { Dir.glob(File.join(fixtures_path(concept_folder), "concept", "*.{yaml,yml}")) }
-  let(:localized_concepts_folder) { File.join(fixtures_path(concept_folder), "localized_concept") }
+  context "when localized_concept (with underscore as separator)" do
+    let(:concept_folder) { "concept_collection_v2" }
+    let(:concept_files) { Dir.glob(File.join(fixtures_path(concept_folder), "concept", "*.{yaml,yml}")) }
+    let(:localized_concepts_folder) { File.join(fixtures_path(concept_folder), "localized_concept") }
 
-  it "correctly loads concepts from files" do
-    collection = Glossarist::ManagedConceptCollection.new
-    collection.load_from_files(fixtures_path(concept_folder))
+    it "correctly loads concepts from files" do
+      collection = Glossarist::ManagedConceptCollection.new
+      collection.load_from_files(fixtures_path(concept_folder))
 
-    concept_files.each do |filename|
-      concept_from_file = load_yaml_file(filename)
-      concept = collection[concept_from_file["data"]["identifier"]]
+      concept_files.each do |filename|
+        concept_from_file = load_yaml_file(filename)
+        concept = collection[concept_from_file["data"]["identifier"]]
 
-      expect(concept.to_h["data"]).to eq(concept_from_file["data"])
+        expect(concept.to_h["data"]).to eq(concept_from_file["data"])
 
-      concept.localized_concepts.each do |lang, id|
-        localized_concept_path = File.join(localized_concepts_folder, "#{id}.yaml")
-        localized_concept = load_yaml_file(localized_concept_path)
+        concept.localized_concepts.each do |lang, id|
+          localized_concept_path = File.join(localized_concepts_folder, "#{id}.yaml")
+          localized_concept = load_yaml_file(localized_concept_path)
 
-        expect(localized_concept["data"]).to eq(concept.localizations[lang].to_h["data"])
+          expect(localized_concept["data"]).to eq(concept.localizations[lang].to_h["data"])
+        end
+      end
+
+      Dir.mktmpdir do |tmp_path|
+        collection.save_to_files(tmp_path)
+
+        # check if concept and localized_concept folder exist
+        system "diff", fixtures_path(concept_folder), tmp_path
+        expect($?.exitstatus).to eq(0) # no difference
+
+        # check content of conecept folder
+        system "diff", File.join(fixtures_path(concept_folder), "concept"), File.join(tmp_path, "concept")
+        expect($?.exitstatus).to eq(0) # no difference
+
+        # check content of localized_conecept folder
+        system "diff", File.join(fixtures_path(concept_folder), "localized_concept"), File.join(tmp_path, "localized_concept")
+        expect($?.exitstatus).to eq(0) # no difference
       end
     end
+  end
 
-    Dir.mktmpdir do |tmp_path|
-      collection.save_to_files(tmp_path)
+  context "when localized-concept (with dash as separator)" do
+    let(:concept_folder) { "concept_collection_v2_dashed" }
+    let(:concept_files) { Dir.glob(File.join(fixtures_path(concept_folder), "concept", "*.{yaml,yml}")) }
+    let(:localized_concepts_folder) { File.join(fixtures_path(concept_folder), "localized-concept") }
 
-      # check if concept and localized_concept folder exist
-      system "diff", fixtures_path(concept_folder), tmp_path
-      expect($?.exitstatus).to eq(0) # no difference
+    it "correctly loads concepts from files" do
+      collection = Glossarist::ManagedConceptCollection.new
+      collection.load_from_files(fixtures_path(concept_folder))
 
-      # check content of conecept folder
-      system "diff", File.join(fixtures_path(concept_folder), "concept"), File.join(tmp_path, "concept")
-      expect($?.exitstatus).to eq(0) # no difference
+      concept_files.each do |filename|
+        concept_from_file = load_yaml_file(filename)
+        concept = collection[concept_from_file["data"]["identifier"]]
 
-      # check content of localized_conecept folder
-      system "diff", File.join(fixtures_path(concept_folder), "localized_concept"), File.join(tmp_path, "localized_concept")
-      expect($?.exitstatus).to eq(0) # no difference
+        expect(concept.to_h["data"]).to eq(concept_from_file["data"])
+
+        concept.localized_concepts.each do |lang, id|
+          localized_concept_path = File.join(localized_concepts_folder, "#{id}.yaml")
+          localized_concept = load_yaml_file(localized_concept_path)
+
+          expect(localized_concept["data"]).to eq(concept.localizations[lang].to_h["data"])
+        end
+      end
+
+      Dir.mktmpdir do |tmp_path|
+        collection.save_to_files(tmp_path)
+
+        # check if concept and localized-concept folder exist
+        system "diff", fixtures_path(concept_folder), tmp_path
+        expect($?.exitstatus).to eq(0) # no difference
+
+        # check content of conecept folder
+        system "diff", File.join(fixtures_path(concept_folder), "concept"), File.join(tmp_path, "concept")
+        expect($?.exitstatus).to eq(0) # no difference
+
+        # check content of localized-conecept folder
+        system "diff", File.join(fixtures_path(concept_folder), "localized-concept"), File.join(tmp_path, "localized-concept")
+        expect($?.exitstatus).to eq(0) # no difference
+      end
     end
   end
 

--- a/spec/fixtures/concept_collection_v1/concept-3.1.1.1.yaml
+++ b/spec/fixtures/concept_collection_v1/concept-3.1.1.1.yaml
@@ -18,6 +18,7 @@ eng:
       process, etc."
   language_code: eng
   entry_status: valid
+  date_accepted: 2008-11-15 00:00:00.000000000 +08:00
   sources:
   - type: authoritative
     origin:

--- a/spec/fixtures/concept_collection_v1/output/concept/3884ac6e-4424-511e-bf9e-9df73577388a.yaml
+++ b/spec/fixtures/concept_collection_v1/output/concept/3884ac6e-4424-511e-bf9e-9df73577388a.yaml
@@ -2,7 +2,7 @@
 data:
   identifier: 3.1.1.1
   localized_concepts:
-    eng: ae27e36e-858c-5026-9dc7-fa366c464f01
+    eng: d7b05924-4158-5341-8167-379f9051fc7f
   groups:
   - foo
   - bar

--- a/spec/fixtures/concept_collection_v1/output/localized_concept/d7b05924-4158-5341-8167-379f9051fc7f.yaml
+++ b/spec/fixtures/concept_collection_v1/output/localized_concept/d7b05924-4158-5341-8167-379f9051fc7f.yaml
@@ -1,6 +1,8 @@
 ---
 data:
-  dates: []
+  dates:
+  - date: 2008-11-15 00:00:00.000000000 +08:00
+    type: accepted
   definition:
   - content: concrete or abstract thing that exists, did exist, or can possibly exist,
       including associations among these things

--- a/spec/fixtures/concept_collection_v2_dashed/concept/003a8c14-f962-5688-aefe-38c736bebfb2.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/concept/003a8c14-f962-5688-aefe-38c736bebfb2.yaml
@@ -1,0 +1,11 @@
+---
+data:
+  identifier: '2119'
+  localized_concepts:
+    eng: da24b782-1551-5128-a043-ba6135a25acf
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative

--- a/spec/fixtures/concept_collection_v2_dashed/concept/00705c76-67c1-5059-a01d-01ac05b1f1ba.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/concept/00705c76-67c1-5059-a01d-01ac05b1f1ba.yaml
@@ -1,0 +1,6 @@
+---
+data:
+  identifier: '1659'
+  localized_concepts:
+    eng: c87dfcd1-c38a-55f9-87bd-9da33bfede80
+    spa: becf3892-886d-5dab-8a7c-af303e576a8d

--- a/spec/fixtures/concept_collection_v2_dashed/concept/00740660-02ea-5fc6-a4d0-b7646a816430.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/concept/00740660-02ea-5fc6-a4d0-b7646a816430.yaml
@@ -1,0 +1,8 @@
+---
+data:
+  identifier: '200'
+  localized_concepts:
+    ara: e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b
+    dan: eaea6d0f-c655-59c9-98f7-9affbdce7612
+    deu: c2cc493d-bc21-50a5-96fc-6774f3d53496
+    eng: 27457e38-89b5-5694-8d19-0dd3973ec71d

--- a/spec/fixtures/concept_collection_v2_dashed/concept/01567592-a7ac-52c0-a158-3a2ecef15b3f.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/concept/01567592-a7ac-52c0-a158-3a2ecef15b3f.yaml
@@ -1,0 +1,7 @@
+---
+data:
+  identifier: '888'
+  localized_concepts:
+    ara: '081154c5-89d6-5192-8147-373bd6060eaa'
+    deu: 527bd617-f471-5523-9b98-59bb181f3df8
+    eng: bf1691ef-6b21-590a-aef1-9e67ad54378e

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/081154c5-89d6-5192-8147-373bd6060eaa.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/081154c5-89d6-5192-8147-373bd6060eaa.yaml
@@ -1,0 +1,26 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: مجموعة من الخصائص التي تكون المفهوم
+  examples: []
+  id: '888'
+  lineage_source_similarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: دلالة
+  language_code: ara

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/27457e38-89b5-5694-8d19-0dd3973ec71d.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/27457e38-89b5-5694-8d19-0dd3973ec71d.yaml
@@ -1,0 +1,31 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: angle from the equatorial plane to the perpendicular to the ellipsoid
+      through a given point, northwards treated as positive
+  examples: []
+  id: '200'
+  lineage_source_similarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normative_status: preferred
+    designation: geodetic latitude
+  - type: expression
+    designation: ellipsoidal latitude
+  language_code: eng

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/527bd617-f471-5523-9b98-59bb181f3df8.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/527bd617-f471-5523-9b98-59bb181f3df8.yaml
@@ -1,0 +1,25 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00.000Z'
+    type: accepted
+  definition: []
+  examples: []
+  id: '888'
+  lineage_source_similarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: Intension
+  language_code: deu

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/becf3892-886d-5dab-8a7c-af303e576a8d.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/becf3892-886d-5dab-8a7c-af303e576a8d.yaml
@@ -1,0 +1,25 @@
+---
+data:
+  dates:
+  - date: '2015-08-15T00:00:00.000Z'
+    type: accepted
+  - date: '2019-07-11T00:00:00.000Z'
+    type: amended
+  definition:
+  - content: sistema de coordenadas que proporciona la posición de los puntos en relación
+      con n ejes mutuamente perpendiculares de curvatura cero
+  examples: []
+  id: '1659'
+  notes:
+  - content: para los propósitos de esta Norma Internacional n es 2 o 3.
+  release: "-4"
+  sources:
+  - origin:
+      ref: ISO 19162:2015
+      clause: 4.1.3
+      link: https://www.iso.org/standard/63094.html
+    type: authoritative
+  terms:
+  - type: expression
+    designation: Sistema de Coordenadas Cartesianas
+  language_code: spa

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/bf1691ef-6b21-590a-aef1-9e67ad54378e.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/bf1691ef-6b21-590a-aef1-9e67ad54378e.yaml
@@ -1,0 +1,26 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: set of characteristics which makes up the concept
+  examples: []
+  id: '888'
+  lineage_source_similarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normative_status: preferred
+    designation: intension
+  language_code: eng

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/c2cc493d-bc21-50a5-96fc-6774f3d53496.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/c2cc493d-bc21-50a5-96fc-6774f3d53496.yaml
@@ -1,0 +1,31 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: Winkel von der Äquatorebene zur Ellipsoidsenkrechten durch einen gegebenen
+      Punkt; nordwärts mit positiven Werten
+  examples: []
+  id: '200'
+  lineage_source_similarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normative_status: preferred
+    designation: geodätische Breite
+  - type: expression
+    designation: ellipsoidal latitude
+  language_code: deu

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/c87dfcd1-c38a-55f9-87bd-9da33bfede80.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/c87dfcd1-c38a-55f9-87bd-9da33bfede80.yaml
@@ -1,0 +1,25 @@
+---
+data:
+  dates:
+  - date: '2015-08-15T00:00:00.000Z'
+    type: accepted
+  - date: '2019-07-11T00:00:00.000Z'
+    type: amended
+  definition:
+  - content: coordinate system which gives the position of points relative to n mutually
+      perpendicular axes that each has zero curvature
+  examples: []
+  id: '1659'
+  notes:
+  - content: n is 2 or 3 for the purposes of this International Standard.
+  release: "-4"
+  sources:
+  - origin:
+      ref: ISO 19162:2015
+      clause: 4.1.3
+      link: https://www.iso.org/standard/63094.html
+    type: authoritative
+  terms:
+  - type: expression
+    designation: Cartesian coordinate system
+  language_code: eng

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/da24b782-1551-5128-a043-ba6135a25acf.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/da24b782-1551-5128-a043-ba6135a25acf.yaml
@@ -1,0 +1,31 @@
+---
+data:
+  dates:
+  - date: '2017-11-15T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: constituent part of a postal address
+  examples:
+  - content: Locality, postcode, thoroughfare, premises identifier
+  id: '2119'
+  notes:
+  - content: The components of postal addresses are defined in 6.2, 6.3 and 6.4.
+  - content: A postal address component may be, but is not limited to, an element,
+      a construct or a segment.
+  - content: For convenience, the preferred term “postal address component” has been
+      shortened to the admitted term “component” throughout this document.
+  release: '5'
+  sources:
+  - origin:
+      ref: ISO 19160-4:2017
+      clause: '3.12'
+      link: https://www.iso.org/standard/64242.html
+    type: authoritative
+  terms:
+  - type: expression
+    normative_status: admitted
+    designation: component
+  - type: expression
+    designation: postal address component
+  domain: postal address
+  language_code: eng

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b.yaml
@@ -1,0 +1,31 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: الزاوية من مستوى خط الاستواء إلى الخط المتعامد مع القطع الناقص عبر نقطة
+      معينة باتجاه الشمال حيث تعتبر موجبة
+  examples: []
+  id: '200'
+  lineage_source_similarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normative_status: preferred
+    designation: خط العرض الجيوديسي
+  - type: expression
+    designation: ellipsoidal latitude
+  language_code: ara

--- a/spec/fixtures/concept_collection_v2_dashed/localized-concept/eaea6d0f-c655-59c9-98f7-9affbdce7612.yaml
+++ b/spec/fixtures/concept_collection_v2_dashed/localized-concept/eaea6d0f-c655-59c9-98f7-9affbdce7612.yaml
@@ -1,0 +1,28 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00.000Z'
+    type: accepted
+  definition:
+  - content: vinkel mellem ækvitorialfladen og den vinkelrette på ellipsoiden gennem
+      et givet punkt, hvor nord regnes positiv
+  examples: []
+  id: '200'
+  lineage_source_similarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: ϕ
+  - type: expression
+    designation: geodætisk bredde
+  language_code: dan


### PR DESCRIPTION
This PR fixes the following 2 issues
- There was an error reading `Time` from yaml concept in V1
- Currently there is only support for `localized_concept` (underscore separated) in V2 and some glossaries are using `localized-concept` (dash separated). So I've added support for both of these directory names.