### PR TITLE
allowing concept ids to be integers as well

### DIFF
--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -74,6 +74,8 @@ module Glossarist
     end
 
     def id=(id)
+      # Some of the glossaries that are not generated using glossarist, contains ids that are integers 
+      # so adding a temporary check until every glossary is updated using glossarist.
       if !id.nil? && (id.is_a?(String) || id.is_a?(Integer))
         @id = id
       else

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -74,9 +74,11 @@ module Glossarist
     end
 
     def id=(id)
-      raise(Glossarist::Error, "Expect id to be a string, Got #{id.class} (#{id})") unless id.is_a?(String) || id.nil?
-
-      @id = id
+      if !id.nil? && (id.is_a?(String) || id.is_a?(Integer))
+        @id = id
+      else
+        raise(Glossarist::Error, "Expect id to be a String or Integer, Got #{id.class} (#{id})")
+      end
     end
     alias :termid= :id=
     alias :identifier= :id=

--- a/spec/unit/localized_concept_spec.rb
+++ b/spec/unit/localized_concept_spec.rb
@@ -13,9 +13,19 @@ RSpec.describe Glossarist::LocalizedConcept do
       .to change { subject.id }.to("456")
   end
 
-  it "raises error if id is not a `String`" do
-    expect { subject.id = 1234 }
-      .to raise_error(Glossarist::Error, "Expect id to be a string, Got Integer (1234)")
+  it "accepts integers as ids" do
+    expect { subject.id = 456 }
+      .to change { subject.id }.to(456)
+  end
+
+  it "raises error if id is nil" do
+    expect { subject.id = nil }
+      .to raise_error(Glossarist::Error, "Expect id to be a String or Integer, Got NilClass ()")
+  end
+
+  it "raises error if id is not a `String` or `Integer`" do
+    expect { subject.id = false }
+      .to raise_error(Glossarist::Error, "Expect id to be a String or Integer, Got FalseClass (false)")
   end
 
   it "accepts strings as language codes" do


### PR DESCRIPTION
Allowing concept ids to be integers because in `isotc211-glossary` the ids are integers and this was causing the site to not build.