### PR TITLE
feat: handled case style conversion

### DIFF
--- a/exe/glossarist
+++ b/exe/glossarist
@@ -21,12 +21,14 @@ class GlossaristCommand < Thor
 
     concept_set = Glossarist::ConceptSet.new(options[:concepts_path], assets)
     latex_str = concept_set.to_latex(latex_concepts_file)
+    output_latex(latex_str)
+  end
 
+  def output_latex(latex_str)
     output_file_path = options[:output_file]
+
     if output_file_path
-      File.open(output_file_path, "w") do |file|
-        file.puts latex_str
-      end
+      File.open(output_file_path, "w") { |file| file.puts latex_str }
     else
       puts latex_str
     end

--- a/glossarist.gemspec
+++ b/glossarist.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "lutaml-model", "~> 0.5.0"
-  spec.add_dependency "relaton", "~> 1.19"
+  spec.add_dependency "lutaml-model", "~> 0.5.4"
+  spec.add_dependency "relaton", "~> 1.20.0"
   spec.add_dependency "thor"
 end

--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -15,14 +15,13 @@ module Glossarist
       map :data, to: :data
       map :termid, to: :termid
       map :subject, to: :subject
-      map :non_verb_rep, to: :non_verb_rep
-      map :extension_attributes, to: :extension_attributes
-      map :lineage_source, to: :lineage_source
+      map %i[non_verb_rep nonVerbRep], to: :non_verb_rep
+      map %i[extension_attributes extensionAttributes], to: :extension_attributes
+      map %i[lineage_source lineageSource], to: :lineage_source
       map :localizations, to: :localizations
-      map :extension_attributes, to: :extension_attributes
+      map %i[extension_attributes extensionAttributes], to: :extension_attributes
 
-      map :date_accepted,
-          with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
+      map %i[date_accepted dateAccepted], with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
       map :uuid, to: :uuid, with: { to: :uuid_to_yaml, from: :uuid_from_yaml }
       map :id, to: :id, with: { to: :id_to_yaml, from: :id_from_yaml }
       map :identifier, to: :id, with: { to: :id_to_yaml, from: :id_from_yaml }

--- a/lib/glossarist/concept_data.rb
+++ b/lib/glossarist/concept_data.rb
@@ -28,7 +28,7 @@ module Glossarist
       map :definition, to: :definition, render_nil: true
       map :examples, to: :examples, render_nil: true
       map :id, to: :id
-      map :lineage_source_similarity, to: :lineage_source_similarity
+      map %i[lineage_source_similarity lineageSourceSimilarity], to: :lineage_source_similarity
       map :notes, to: :notes, render_nil: true
       map :release, to: :release
       map :sources, to: :sources
@@ -36,11 +36,11 @@ module Glossarist
                   with: { from: :terms_from_yaml, to: :terms_to_yaml }
       map :related, to: :related
       map :domain, to: :domain
-      map :language_code, to: :language_code
-      map :entry_status, to: :entry_status
-      map :review_date, to: :review_date
-      map :review_decision_date, to: :review_decision_date
-      map :review_decision_event, to: :review_decision_event
+      map %i[language_code languageCode], to: :language_code
+      map %i[entry_status entryStatus], to: :entry_status
+      map %i[review_date reviewDate], to: :review_date
+      map %i[review_decision_date reviewDecisionDate], to: :review_decision_date
+      map %i[review_decision_event reviewDecisionEvent], to: :review_decision_event
     end
 
     def terms_from_yaml(model, value)

--- a/lib/glossarist/concept_manager.rb
+++ b/lib/glossarist/concept_manager.rb
@@ -5,7 +5,7 @@ module Glossarist
 
     yaml do
       map :path, to: :path
-      map :localized_concepts_path, to: :localized_concepts_path
+      map %i[localized_concepts_path localizedConceptsPath], to: :localized_concepts_path
     end
 
     def load_from_files(collection: nil)

--- a/lib/glossarist/designation/base.rb
+++ b/lib/glossarist/designation/base.rb
@@ -9,8 +9,8 @@ module Glossarist
 
       yaml do
         map :type, to: :type
-        map :normative_status, to: :normative_status
-        map :geographical_area, to: :geographical_area
+        map %i[normative_status normativeStatus], to: :normative_status
+        map %i[geographical_area geographicalArea], to: :geographical_area
         map :designation, to: :designation
       end
 

--- a/lib/glossarist/designation/expression.rb
+++ b/lib/glossarist/designation/expression.rb
@@ -16,8 +16,8 @@ module Glossarist
       yaml do
         map :type, to: :type, render_default: true
         map :prefix, to: :prefix
-        map :usage_info, to: :usage_info
-        map :grammar_info, to: :grammar_info
+        map %i[usage_info usageInfo], to: :usage_info
+        map %i[grammar_info grammarInfo], to: :grammar_info
       end
 
       def self.of_yaml(hash, options = {})

--- a/lib/glossarist/designation/grammar_info.rb
+++ b/lib/glossarist/designation/grammar_info.rb
@@ -12,9 +12,7 @@ module Glossarist
         map :gender, to: :gender
         map :number, to: :number
 
-        map :part_of_speech,
-            with: { to: :part_of_speech_to_yaml,
-                    from: :part_of_speech_from_yaml }
+        map %i[part_of_speech partOfSpeech], with: { to: :part_of_speech_to_yaml, from: :part_of_speech_from_yaml }
         Glossarist::GlossaryDefinition::GRAMMAR_INFO_BOOLEAN_ATTRIBUTES.each do |bool_attr|
           map bool_attr,
               with: { to: :"part_of_speech_#{bool_attr}_to_yaml",

--- a/lib/glossarist/localized_concept.rb
+++ b/lib/glossarist/localized_concept.rb
@@ -6,7 +6,7 @@ module Glossarist
 
     yaml do
       map :classification, to: :classification
-      map :review_type, to: :review_type
+      map %i[review_type reviewType], to: :review_type
     end
 
     alias_method :status=, :entry_status=

--- a/lib/glossarist/managed_concept.rb
+++ b/lib/glossarist/managed_concept.rb
@@ -28,8 +28,7 @@ module Glossarist
           with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
       map :related, to: :related
       map :dates, to: :dates
-      map :date_accepted,
-          with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
+      map %i[date_accepted dateAccepted], with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
       map :status, to: :status
 
       map :uuid, to: :uuid, with: { from: :uuid_from_yaml, to: :uuid_to_yaml }

--- a/spec/fixtures/concept_collection_v2_camel_cased/concept/003a8c14-f962-5688-aefe-38c736bebfb2.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/concept/003a8c14-f962-5688-aefe-38c736bebfb2.yaml
@@ -1,0 +1,12 @@
+---
+data:
+  identifier: '2119'
+  localizedConcepts:
+    eng: da24b782-1551-5128-a043-ba6135a25acf
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+id: 003a8c14-f962-5688-aefe-38c736bebfb2

--- a/spec/fixtures/concept_collection_v2_camel_cased/concept/00705c76-67c1-5059-a01d-01ac05b1f1ba.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/concept/00705c76-67c1-5059-a01d-01ac05b1f1ba.yaml
@@ -1,0 +1,7 @@
+---
+data:
+  identifier: '1659'
+  localizedConcepts:
+    eng: c87dfcd1-c38a-55f9-87bd-9da33bfede80
+    spa: becf3892-886d-5dab-8a7c-af303e576a8d
+id: 00705c76-67c1-5059-a01d-01ac05b1f1ba

--- a/spec/fixtures/concept_collection_v2_camel_cased/concept/00740660-02ea-5fc6-a4d0-b7646a816430.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/concept/00740660-02ea-5fc6-a4d0-b7646a816430.yaml
@@ -1,0 +1,9 @@
+---
+data:
+  identifier: '200'
+  localizedConcepts:
+    ara: e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b
+    dan: eaea6d0f-c655-59c9-98f7-9affbdce7612
+    deu: c2cc493d-bc21-50a5-96fc-6774f3d53496
+    eng: 27457e38-89b5-5694-8d19-0dd3973ec71d
+id: 00740660-02ea-5fc6-a4d0-b7646a816430

--- a/spec/fixtures/concept_collection_v2_camel_cased/concept/01567592-a7ac-52c0-a158-3a2ecef15b3f.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/concept/01567592-a7ac-52c0-a158-3a2ecef15b3f.yaml
@@ -1,0 +1,8 @@
+---
+data:
+  identifier: '888'
+  localizedConcepts:
+    ara: '081154c5-89d6-5192-8147-373bd6060eaa'
+    deu: 527bd617-f471-5523-9b98-59bb181f3df8
+    eng: bf1691ef-6b21-590a-aef1-9e67ad54378e
+id: '01567592-a7ac-52c0-a158-3a2ecef15b3f'

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/081154c5-89d6-5192-8147-373bd6060eaa.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/081154c5-89d6-5192-8147-373bd6060eaa.yaml
@@ -1,0 +1,28 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: مجموعة من الخصائص التي تكون المفهوم
+  examples: []
+  id: '888'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normativeStatus: preferred
+    designation: دلالة
+  languageCode: ara
+dateAccepted: '2010-11-01T00:00:00+00:00'
+id: '081154c5-89d6-5192-8147-373bd6060eaa'

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/27457e38-89b5-5694-8d19-0dd3973ec71d.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/27457e38-89b5-5694-8d19-0dd3973ec71d.yaml
@@ -1,0 +1,33 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: angle from the equatorial plane to the perpendicular to the ellipsoid
+      through a given point, northwards treated as positive
+  examples: []
+  id: '200'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normativeStatus: preferred
+    designation: geodetic latitude
+  - type: expression
+    designation: ellipsoidal latitude
+  languageCode: eng
+dateAccepted: '2003-02-15T00:00:00+00:00'
+id: 27457e38-89b5-5694-8d19-0dd3973ec71d

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/527bd617-f471-5523-9b98-59bb181f3df8.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/527bd617-f471-5523-9b98-59bb181f3df8.yaml
@@ -1,0 +1,27 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00+00:00'
+    type: accepted
+  definition: []
+  examples: []
+  id: '888'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normativeStatus: preferred
+    designation: Intension
+  languageCode: deu
+dateAccepted: '2010-11-01T00:00:00+00:00'
+id: 527bd617-f471-5523-9b98-59bb181f3df8

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/becf3892-886d-5dab-8a7c-af303e576a8d.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/becf3892-886d-5dab-8a7c-af303e576a8d.yaml
@@ -1,0 +1,27 @@
+---
+data:
+  dates:
+  - date: '2015-08-15T00:00:00+00:00'
+    type: accepted
+  - date: '2019-07-11T00:00:00+00:00'
+    type: amended
+  definition:
+  - content: sistema de coordenadas que proporciona la posición de los puntos en relación
+      con n ejes mutuamente perpendiculares de curvatura cero
+  examples: []
+  id: '1659'
+  notes:
+  - content: para los propósitos de esta Norma Internacional n es 2 o 3.
+  release: "-4"
+  sources:
+  - origin:
+      ref: ISO 19162:2015
+      clause: 4.1.3
+      link: https://www.iso.org/standard/63094.html
+    type: authoritative
+  terms:
+  - type: expression
+    designation: Sistema de Coordenadas Cartesianas
+  languageCode: spa
+dateAccepted: '2015-08-15T00:00:00+00:00'
+id: becf3892-886d-5dab-8a7c-af303e576a8d

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/bf1691ef-6b21-590a-aef1-9e67ad54378e.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/bf1691ef-6b21-590a-aef1-9e67ad54378e.yaml
@@ -1,0 +1,28 @@
+---
+data:
+  dates:
+  - date: '2010-11-01T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: set of characteristics which makes up the concept
+  examples: []
+  id: '888'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '2'
+  sources:
+  - origin:
+      ref: ISO 1087-1:2000
+      clause: 3.2.9
+      link: https://www.iso.org/standard/20057.html
+    type: authoritative
+  - origin:
+      ref: ISO 19146:2010(E)
+    type: lineage
+  terms:
+  - type: expression
+    normativeStatus: preferred
+    designation: intension
+  languageCode: eng
+dateAccepted: '2010-11-01T00:00:00+00:00'
+id: bf1691ef-6b21-590a-aef1-9e67ad54378e

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/c2cc493d-bc21-50a5-96fc-6774f3d53496.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/c2cc493d-bc21-50a5-96fc-6774f3d53496.yaml
@@ -1,0 +1,33 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: Winkel von der Äquatorebene zur Ellipsoidsenkrechten durch einen gegebenen
+      Punkt; nordwärts mit positiven Werten
+  examples: []
+  id: '200'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normativeStatus: preferred
+    designation: geodätische Breite
+  - type: expression
+    designation: ellipsoidal latitude
+  languageCode: deu
+dateAccepted: '2003-02-15T00:00:00+00:00'
+id: c2cc493d-bc21-50a5-96fc-6774f3d53496

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/c87dfcd1-c38a-55f9-87bd-9da33bfede80.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/c87dfcd1-c38a-55f9-87bd-9da33bfede80.yaml
@@ -1,0 +1,27 @@
+---
+data:
+  dates:
+  - date: '2015-08-15T00:00:00+00:00'
+    type: accepted
+  - date: '2019-07-11T00:00:00+00:00'
+    type: amended
+  definition:
+  - content: coordinate system which gives the position of points relative to n mutually
+      perpendicular axes that each has zero curvature
+  examples: []
+  id: '1659'
+  notes:
+  - content: n is 2 or 3 for the purposes of this International Standard.
+  release: "-4"
+  sources:
+  - origin:
+      ref: ISO 19162:2015
+      clause: 4.1.3
+      link: https://www.iso.org/standard/63094.html
+    type: authoritative
+  terms:
+  - type: expression
+    designation: Cartesian coordinate system
+  languageCode: eng
+dateAccepted: '2015-08-15T00:00:00+00:00'
+id: c87dfcd1-c38a-55f9-87bd-9da33bfede80

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/da24b782-1551-5128-a043-ba6135a25acf.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/da24b782-1551-5128-a043-ba6135a25acf.yaml
@@ -1,0 +1,33 @@
+---
+data:
+  dates:
+  - date: '2017-11-15T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: constituent part of a postal address
+  examples:
+  - content: Locality, postcode, thoroughfare, premises identifier
+  id: '2119'
+  notes:
+  - content: The components of postal addresses are defined in 6.2, 6.3 and 6.4.
+  - content: A postal address component may be, but is not limited to, an element,
+      a construct or a segment.
+  - content: For convenience, the preferred term “postal address component” has been
+      shortened to the admitted term “component” throughout this document.
+  release: '5'
+  sources:
+  - origin:
+      ref: ISO 19160-4:2017
+      clause: '3.12'
+      link: https://www.iso.org/standard/64242.html
+    type: authoritative
+  terms:
+  - type: expression
+    normativeStatus: admitted
+    designation: component
+  - type: expression
+    designation: postal address component
+  domain: postal address
+  languageCode: eng
+dateAccepted: '2017-11-15T00:00:00+00:00'
+id: da24b782-1551-5128-a043-ba6135a25acf

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b.yaml
@@ -1,0 +1,33 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: الزاوية من مستوى خط الاستواء إلى الخط المتعامد مع القطع الناقص عبر نقطة
+      معينة باتجاه الشمال حيث تعتبر موجبة
+  examples: []
+  id: '200'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: j
+  - type: expression
+    normativeStatus: preferred
+    designation: خط العرض الجيوديسي
+  - type: expression
+    designation: ellipsoidal latitude
+  languageCode: ara
+dateAccepted: '2003-02-15T00:00:00+00:00'
+id: e4ee4f5c-07b0-577e-8bc0-37e0f98d7a2b

--- a/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/eaea6d0f-c655-59c9-98f7-9affbdce7612.yaml
+++ b/spec/fixtures/concept_collection_v2_camel_cased/localized_concept/eaea6d0f-c655-59c9-98f7-9affbdce7612.yaml
@@ -1,0 +1,30 @@
+---
+data:
+  dates:
+  - date: '2003-02-15T00:00:00+00:00'
+    type: accepted
+  definition:
+  - content: vinkel mellem ækvitorialfladen og den vinkelrette på ellipsoiden gennem
+      et givet punkt, hvor nord regnes positiv
+  examples: []
+  id: '200'
+  lineageSourceSimilarity: 1
+  notes: []
+  release: '1'
+  sources:
+  - origin:
+      ref: ISO 19111:2019
+      clause: 3.1.32
+      link: https://www.iso.org/standard/74039.html
+    type: authoritative
+  - origin:
+      ref: ISO 19111:2003
+    type: lineage
+  terms:
+  - type: abbreviation
+    designation: ϕ
+  - type: expression
+    designation: geodætisk bredde
+  languageCode: dan
+dateAccepted: '2003-02-15T00:00:00+00:00'
+id: eaea6d0f-c655-59c9-98f7-9affbdce7612


### PR DESCRIPTION
Handled asynchronous cases where `Paneron`/`Glossarist` uses **camelCase** while `glossarist-ruby` uses **snake_case**

closes #114