### PR TITLE
chore: move sts and tbx deps to gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,5 +14,5 @@ gem "rubocop"
 gem "rubocop-performance"
 gem "rubocop-rake"
 gem "rubocop-rspec"
-gem "sts", "~> 0.5.6"
-gem "tbx", "~> 0.1"
+
+

--- a/glossarist.gemspec
+++ b/glossarist.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "lutaml-model", "~> 0.8.5"
+  spec.add_dependency "sts", "~> 0.5.6"
   spec.add_dependency "relaton", ">= 2.0.0", "< 3"
   spec.add_dependency "rubyzip", ">= 2.3", "< 3"
   spec.add_dependency "tbx", "~> 0.1"


### PR DESCRIPTION
Move `sts` and `tbx` from Gemfile to gemspec as runtime dependencies so they're installed automatically for end users.