### PR TITLE
feat: align glossarist-ruby with concept-model v3 ontology

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -57,6 +57,7 @@ related_concept:
     - narrower_instantial
     # Equivalence (ISO 10241-1 / ISO 25964 exactMatch / SKOS)
     - equivalent
+    - exact_match
     # Approximate equivalence (ISO 25964 closeMatch / SKOS)
     - close_match
     # Cross-vocabulary mapping (SKOS)
@@ -92,11 +93,19 @@ iso12620:
     - short_form
     - transliterated_form
     - transcribed_form
+    - truncation
     - variant
     # Symbolic / formulaic:
+    - code
     - equation
+    - figure_symbol
     - formula
+    - graphic_symbol
+    - letter_symbol
     - logical_expression
+    - mathematical_expression
+    - reference_symbol
+    - roman_numeral
     - symbol
     # Usage / provenance:
     - common_name
@@ -104,7 +113,9 @@ iso12620:
     - internationalism
     - international_scientific_term
     - part_number
+    - phrase
     - phraseological_unit
+    - scientific_name
     - shortcut
     - sku
     - standard_text

--- a/spec/fixtures/concept-model-examples/v2/01-minimal-concept.yaml
+++ b/spec/fixtures/concept-model-examples/v2/01-minimal-concept.yaml
@@ -1,0 +1,36 @@
+# 01 — Minimal Concept
+#
+# The smallest valid managed concept: an id, a localization map, and status.
+# Demonstrates identity, localization map, and lifecycle metadata.
+
+---
+id: "113-01-01"
+data:
+  identifier: "113-01-01"
+
+  # Optional URI reference for the concept (external representation)
+  uri: "urn:iec:std:iec:60050-113-01-01"
+
+  # Maps ISO 639 language codes to localized concept UUIDs.
+  # The actual localized concept data lives in separate files.
+  localized_concepts:
+    eng: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-113"
+        version: "2011"
+
+status: valid
+
+# Simplified date — internally mapped to ConceptDate(type: accepted)
+date_accepted: "2011-04-01T00:00:00+00:00"
+
+# Structured dates are also supported:
+# dates:
+#   - date: "2011-04-01T00:00:00+00:00"
+#     type: accepted
+#   - date: "2019-03-01T00:00:00+00:00"
+#     type: amended

--- a/spec/fixtures/concept-model-examples/v2/01-minimal-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/01-minimal-localized.yaml
@@ -1,0 +1,25 @@
+# 01 — Minimal Localized Concept
+#
+# The smallest valid localized concept: id, language, term, definition, source.
+
+---
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "length"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        distance between two points
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-113"
+        version: "2011"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/02-designation-abbreviation.yaml
+++ b/spec/fixtures/concept-model-examples/v2/02-designation-abbreviation.yaml
@@ -1,0 +1,53 @@
+# 02 — Designation: Abbreviation
+#
+# Abbreviation designations extend Expression with type booleans:
+# acronym, initialism, truncation. Also supports designation-level relationships.
+
+---
+id: c1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+
+  terms:
+    # Full form (preferred)
+    - type: expression
+      designation: "Light Emitting Diode"
+      normative_status: preferred
+
+    # Acronym — pronounced as a word
+    - type: abbreviation
+      designation: "LED"
+      normative_status: admitted
+      acronym: true
+      # Designation-level relationship: this abbreviation is the
+      # abbreviated form of the preferred term above
+      related:
+        - type: abbreviated_form_for
+          target: "Light Emitting Diode"
+
+    # Another example: initialism (each letter pronounced separately)
+    - type: abbreviation
+      designation: "HTML"
+      normative_status: admitted
+      initialism: true
+
+    # Truncation — shortened by cutting off the end
+    - type: abbreviation
+      designation: "app"
+      normative_status: admitted
+      truncation: true
+      related:
+        - type: short_form_for
+          target: "application"
+
+  definition:
+    - content: >-
+        a semiconductor device that emits light when current flows through it
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-521"
+        version: "2002"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/02-designation-expression.yaml
+++ b/spec/fixtures/concept-model-examples/v2/02-designation-expression.yaml
@@ -1,0 +1,123 @@
+# 02 — Designation: Expression
+#
+# Expression designations are words or phrases — the most common type.
+# Shows normative_status, grammar_info, usage_info, field_of_application,
+# term_type (ISO 12620), and designation-level sources.
+
+---
+id: b1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+
+  terms:
+    # Preferred term with full grammar info (noun, singular)
+    - type: expression
+      designation: "color"
+      normative_status: preferred
+      geographical_area: US
+      grammar_info:
+        - noun: true
+          number: singular
+      term_type: full_form
+
+    # Admitted alternative — different geographical area
+    - type: expression
+      designation: "colour"
+      normative_status: admitted
+      geographical_area: GB
+      grammar_info:
+        - noun: true
+          number: singular
+      term_type: variant
+
+    # Deprecated term with usage context and part-of-speech
+    - type: expression
+      designation: "colour signal"
+      normative_status: deprecated
+      usage_info: "television"
+      field_of_application: "in analogue television"
+      grammar_info:
+        - noun: true
+          number: singular
+      term_type: entry_term
+
+    # Verb form with its own grammar info
+    - type: expression
+      designation: "to color"
+      normative_status: admitted
+      grammar_info:
+        - verb: true
+      term_type: full_form
+
+    # Adjective form — dual gender, plural number
+    - type: expression
+      designation: "colorful"
+      normative_status: admitted
+      grammar_info:
+        - adj: true
+          gender: [m, f]
+          number: plural
+
+    # Adverb form
+    - type: expression
+      designation: "colorfully"
+      normative_status: admitted
+      grammar_info:
+        - adverb: true
+
+    # Participle form
+    - type: expression
+      designation: "coloring"
+      normative_status: admitted
+      grammar_info:
+        - participle: true
+
+    # Preposition usage
+    - type: expression
+      designation: "in color"
+      normative_status: admitted
+      grammar_info:
+        - preposition: true
+
+    # Expression with prefix
+    - type: expression
+      designation: "color"
+      normative_status: admitted
+      prefix: "non-"
+      usage_info: "pigment chemistry"
+
+    # Common name term type (ISO 12620)
+    - type: expression
+      designation: "sun"
+      normative_status: admitted
+      term_type: common_name
+
+    # Synonym (ISO 12620)
+    - type: expression
+      designation: "hue"
+      normative_status: admitted
+      term_type: synonym
+
+    # Designation-level source (ISO 10241-1 §6.8)
+    - type: expression
+      designation: "chromatic"
+      normative_status: admitted
+      sources:
+        - type: authoritative
+          status: identical
+          origin:
+            source: "IEC"
+            id: "60050-845"
+            version: "2020"
+
+  definition:
+    - content: >-
+        visual sensation produced by light of a specific wavelength
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-845"
+        version: "2020"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/02-designation-symbol.yaml
+++ b/spec/fixtures/concept-model-examples/v2/02-designation-symbol.yaml
@@ -1,0 +1,44 @@
+# 02 — Designation: Symbol, Letter Symbol, Graphical Symbol
+#
+# Three symbol designation types, each inheriting from Base.
+# Symbols are often international (valid across languages).
+
+---
+id: d1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+
+  terms:
+    # Symbol — a non-letter symbol
+    - type: symbol
+      designation: "Ω"
+      normative_status: preferred
+      international: true
+
+    # Letter symbol — a letter used as a symbol
+    - type: letter_symbol
+      designation: "R"
+      text: "R"
+      normative_status: admitted
+      international: true
+
+    # Graphical symbol — an iconic or graphical symbol
+    - type: graphical_symbol
+      designation: "warning sign"
+      text: "general warning"
+      image: "⚠"
+      normative_status: preferred
+      international: true
+
+  definition:
+    - content: >-
+        a designation that is not a word or an abbreviation, used to represent
+        a concept in a given language
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "ISO"
+        id: "10241-1"
+        version: "2011"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/03-pronunciation.yaml
+++ b/spec/fixtures/concept-model-examples/v2/03-pronunciation.yaml
@@ -1,0 +1,52 @@
+# 03 — Pronunciation & Per-Designation Language Overrides
+#
+# Pronunciations attach to individual designations. Each pronunciation entry
+# can specify its own language, script, country, and transcription system.
+# Designations can also override the concept-level language/script/system.
+
+---
+id: e1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: jpn
+  script: Hani
+
+  terms:
+    # Japanese term with two pronunciations in different systems
+    - type: expression
+      designation: "東京"
+      normative_status: preferred
+
+      # Multiple pronunciations for different romanization systems
+      pronunciation:
+        # Hepburn romanization (ISO 24229 system code)
+        - content: "Tōkyō"
+          language: jpn
+          script: Latn
+          system: "Var:jpn-Hrkt:Latn:Hepburn-1886"
+
+        # IPA phonetic transcription
+        - content: "toːkjoː"
+          language: jpn
+          script: Latn
+          system: IPA
+
+    # A designation in a different script overrides the concept-level script
+    - type: expression
+      designation: "とうきょう"
+      normative_status: admitted
+      script: Hrkt
+      pronunciation:
+        - content: "Tōkyō"
+          language: jpn
+          script: Latn
+          system: "Var:jpn-Hrkt:Latn:Hepburn-1886"
+
+  definition:
+    - content: >-
+        capital city of Japan
+
+  sources:
+    - type: authoritative
+      origin:
+        text: "Example pronunciation data"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/04-definition-notes-examples.yaml
+++ b/spec/fixtures/concept-model-examples/v2/04-definition-notes-examples.yaml
@@ -1,0 +1,59 @@
+# 04 — Definition, Notes, and Examples
+#
+# Definitions, notes, and examples all use DetailedDefinition —
+# text content with optional per-item sources.
+
+---
+id: f1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "resistance"
+      normative_status: preferred
+      grammar_info:
+        - noun: true
+
+    - type: symbol
+      designation: "R"
+      normative_status: admitted
+      international: true
+
+  # Primary definition — can have sources specific to this definition
+  definition:
+    - content: >-
+        quotient of the voltage and the current in a conductor at a given
+        temperature
+      sources:
+        - type: authoritative
+          origin:
+            source: "IEC"
+            id: "60050-131"
+            version: "2002"
+
+  # Supplementary notes — each is a DetailedDefinition
+  notes:
+    - content: >-
+        Resistance is a property of a conductor and depends on its dimensions,
+        material, and temperature.
+    - content: >-
+        The SI unit of resistance is the ohm (Ω).
+      sources:
+        - type: lineage
+          origin:
+            text: "SI Brochure, 9th edition"
+
+  # Illustrative examples — also DetailedDefinition
+  examples:
+    - content: >-
+        A copper wire 1 m long with a cross-section of 1 mm² has a resistance
+        of approximately 0.017 Ω at 20 °C.
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-131"
+        version: "2002"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/05-domains-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/05-domains-localized.yaml
@@ -1,0 +1,34 @@
+# 05 — Domains (Localized): per-language domain URI
+#
+# LocalizedConcept.data.domain is a simple URI string.
+# It can be relative, a URN, or an HTTP URL.
+
+---
+id: 11111111-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  # Per-language domain — URI string (not a ConceptReference)
+  # Three MECE URI forms:
+  domain: "urn:iec:std:iec:60050-103-01"
+  # Alternative forms:
+  #   domain: "section-103-01"                    # relative URI
+  #   domain: "https://www.electropedia.org/..."  # HTTP URL
+
+  terms:
+    - type: expression
+      designation: "functional"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        relating to a correspondence that associates uniquely to each element
+        of a set an element of another set
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-103"
+        version: "2009"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/05-domains.yaml
+++ b/spec/fixtures/concept-model-examples/v2/05-domains.yaml
@@ -1,0 +1,32 @@
+# 05 — Domains (Classification)
+#
+# Domains classify a concept into subject areas — language-agnostic tags.
+# ManagedConcept.data.domains is a ConceptReference array with ref_type "domain".
+# LocalizedConcept.data.domain is a per-language URI string.
+
+---
+id: "103-01-02"
+data:
+  identifier: "103-01-02"
+  localized_concepts:
+    eng: 11111111-aaaa-bbbb-cccc-dddddddddddd
+
+  # Domains: classification into subject areas
+  # These are ConceptReference objects with ref_type "domain"
+  domains:
+    # Local domain reference
+    - concept_id: "103"
+      source: "urn:iec:std:iec:60050"
+      ref_type: "domain"
+    - concept_id: "103-01"
+      source: "urn:iec:std:iec:60050"
+      ref_type: "domain"
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-103"
+        version: "2009"
+status: valid
+date_accepted: "2009-12-14T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/06-related-localized-fra.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-localized-fra.yaml
@@ -1,0 +1,38 @@
+# 06 — Related Concepts (French — false_friend)
+#
+# The French variant has a `false_friend` relationship (ISO 12620/TBX)
+# that the English variant does not. This demonstrates language-specific
+# relationships.
+
+---
+id: 33333333-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: fra
+
+  terms:
+    - type: expression
+      designation: "mesure"
+      normative_status: preferred
+      grammar_info:
+        - gender: f
+          number: singular
+
+  definition:
+    - content: >-
+        ensemble d'opérations ayant pour but de déterminer la valeur d'une
+        grandeur
+
+  # Language-specific: false_friend only exists in French
+  related:
+    - type: false_friend
+      content: "measure (English, musical sense)"
+      ref:
+        text: "measure"
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/06-related-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-localized.yaml
@@ -1,0 +1,37 @@
+# 06 — Related Concepts (Language-Specific)
+#
+# LocalizedConcept.data.related holds relationships that only exist in
+# one language variant. For example, French "mesure" has a false_friend
+# relationship that English "measurement" does not.
+
+---
+id: 22222222-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "system"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        set of interrelated elements considered in a defined context as a whole
+        and separated from their environment
+
+  # Language-specific relationships
+  related:
+    # Associative cross-reference
+    - type: see
+      content: "open system"
+      ref:
+        source: "IEC"
+        id: "102-03-05"
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-102"
+        version: "2007"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/06-related-relationships.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-relationships.yaml
@@ -1,0 +1,202 @@
+# 06 — Related Concepts (All Typed Semantic Relationships)
+#
+# Relationships are typed semantic links between concepts, spanning:
+# - ISO 10241-1: lifecycle (deprecates, supersedes, superseded_by),
+#   comparative (compare, contrast), associative (see)
+# - ISO 25964 / SKOS: hierarchical (broader, narrower) with generic/
+#   partitive/instantial subtypes, equivalence (equivalent),
+#   approximate mapping (close_match, broad_match, narrow_match,
+#   related_match)
+# - ISO 12620 / TBX: associative subtypes (related_concept,
+#   related_concept_broader, related_concept_narrower),
+#   spatiotemporal (sequentially_related, spatially_related,
+#   temporally_related), lexical (homograph, false_friend)
+#
+# false_friend and language-specific relationships are demonstrated
+# in the localized companion files.
+
+---
+id: "102-03-01"
+data:
+  identifier: "102-03-01"
+  localized_concepts:
+    eng: 22222222-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-102"
+        version: "2007"
+
+related:
+  # ── Hierarchical (ISO 10241-1 / ISO 25964 BT/NT) ──────────────────────
+  - type: broader
+    content: "complex system"
+    ref:
+      source: "IEC"
+      id: "102-03-02"
+
+  - type: narrower
+    content: "subsystem"
+    ref:
+      source: "IEC"
+      id: "102-03-03"
+
+  # ── ISO 25964 Generic Hierarchy (BTG/NTG) ─────────────────────────────
+  # "is a kind of" — generic/specific relationship
+  - type: broader_generic
+    content: "physical system"
+    ref:
+      source: "IEC"
+      id: "102-01-01"
+
+  - type: narrower_generic
+    content: "closed system"
+    ref:
+      source: "IEC"
+      id: "102-03-04"
+
+  # ── ISO 25964 Partitive Hierarchy (BTP/NTP) ───────────────────────────
+  # "is a part of" — whole/part relationship (transitive)
+  - type: broader_partitive
+    content: "larger assembly"
+    ref:
+      source: "IEC"
+      id: "102-05-01"
+
+  - type: narrower_partitive
+    content: "system component"
+    ref:
+      source: "IEC"
+      id: "102-05-02"
+
+  # ── ISO 25964 Instantial Hierarchy (BTI/NTI) ───────────────────────────
+  # "is an instance of" — class/instance relationship
+  - type: broader_instantial
+    content: "thermodynamic system (class)"
+    ref:
+      source: "IEC"
+      id: "102-06-01"
+
+  - type: narrower_instantial
+    content: "specific Carnot engine"
+    ref:
+      source: "IEC"
+      id: "102-06-02"
+
+  # ── Equivalence (SKOS exactMatch) ─────────────────────────────────────
+  - type: equivalent
+    content: "system (general systems theory)"
+    ref:
+      source: "ISO"
+      id: "10241-1"
+
+  # ── SKOS Mapping Properties ───────────────────────────────────────────
+  - type: close_match
+    ref:
+      text: "system (general systems theory)"
+
+  - type: broad_match
+    content: "related broader concept in another vocabulary"
+    ref:
+      source: "ISO"
+      id: "1087-1"
+
+  - type: narrow_match
+    content: "related narrower concept in another vocabulary"
+    ref:
+      source: "ISO"
+      id: "1087-2"
+
+  - type: related_match
+    content: "related concept in another vocabulary"
+    ref:
+      source: "IEC"
+      id: "60050-151"
+
+  # ── Comparative (ISO 10241-1) ─────────────────────────────────────────
+  - type: compare
+    content: "closed system"
+    ref:
+      source: "IEC"
+      id: "102-03-04"
+
+  - type: contrast
+    content: "environment"
+    ref:
+      source: "IEC"
+      id: "102-03-06"
+
+  # ── Associative (ISO 10241-1 / ISO 25964 RT) ─────────────────────────
+  - type: see
+    content: "open system"
+    ref:
+      source: "IEC"
+      id: "102-03-05"
+
+  # ── Associative Subtypes (ISO 25964 / TBX) ────────────────────────────
+  - type: related_concept
+    content: "boundary of a system"
+    ref:
+      source: "IEC"
+      id: "102-04-01"
+
+  - type: related_concept_broader
+    content: "system boundary (broader sense)"
+    ref:
+      source: "IEC"
+      id: "102-04-02"
+
+  - type: related_concept_narrower
+    content: "permeable boundary (narrower sense)"
+    ref:
+      source: "IEC"
+      id: "102-04-03"
+
+  # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
+  - type: sequentially_related_concept
+    content: "next process step"
+    ref:
+      source: "IEC"
+      id: "102-07-01"
+
+  - type: spatially_related_concept
+    content: "adjacent region"
+    ref:
+      source: "IEC"
+      id: "102-07-02"
+
+  - type: temporally_related_concept
+    content: "preceding state"
+    ref:
+      source: "IEC"
+      id: "102-07-03"
+
+  # ── Lifecycle (ISO 10241-1) ───────────────────────────────────────────
+  - type: supersedes
+    ref:
+      source: "IEC"
+      id: "102-03-00"
+
+  - type: superseded_by
+    content: "replaced by newer concept"
+    ref:
+      source: "IEC"
+      id: "102-03-10"
+
+  - type: deprecates
+    content: "old deprecated term"
+    ref:
+      source: "IEC"
+      id: "102-03-11"
+
+  # ── Lexical (ISO 12620 / TBX) ─────────────────────────────────────────
+  # false_friend is language-specific — see 06-related-localized-fra.yaml
+  - type: homograph
+    content: "same spelling, different meaning"
+    ref:
+      source: "IEC"
+      id: "102-08-01"
+
+status: valid
+date_accepted: "2007-08-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/07-sources-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/07-sources-localized.yaml
@@ -1,0 +1,173 @@
+# 07 — Sources (Localized — all source features)
+#
+# Comprehensive demonstration of sources and citations at all levels:
+# localized concept, definition, note, example, and designation.
+# Shows all source status values, citation locality features
+# (ranges, custom_locality, link), and modification notes.
+
+---
+id: 44444444-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "standard"
+      normative_status: preferred
+
+      # Designation-level source (ISO 10241-1 §6.8)
+      sources:
+        - type: authoritative
+          status: identical
+          origin:
+            source: "ISO"
+            id: "10241-1"
+            version: "2011"
+
+  # Definition with modified source — status indicates how it was changed
+  definition:
+    - content: >-
+        a document established by consensus and approved by a recognized body
+        that provides rules, guidelines or characteristics
+      sources:
+        - type: authoritative
+          status: modified
+          origin:
+            source: "ISO"
+            id: "10241-1"
+            version: "2011"
+            clause: "3.1"
+          modification: >-
+            replaced "for common and repeated use" with broader wording
+
+  # Notes demonstrating source status values
+  notes:
+    # similar — close but not identical
+    - content: >-
+        Standards include but are not limited to international standards,
+        regional standards, and national standards.
+      sources:
+        - type: lineage
+          status: similar
+          origin:
+            text: "ISO/IEC Guide 2"
+
+    # context_added — original meaning preserved with added context
+    - content: >-
+        The term "standard" also applies to de facto standards that arise
+        through widespread adoption.
+      sources:
+        - type: lineage
+          status: context_added
+          origin:
+            source: "ISO"
+            id: "IEC Guide 2"
+            version: "2004"
+
+    # generalisation — source was narrower, generalised for this concept
+    - content: >-
+        Standards may cover products, processes, or services.
+      sources:
+        - type: authoritative
+          status: generalisation
+          origin:
+            source: "ISO"
+            id: "10241-1"
+            version: "2011"
+          modification: "generalised from product standards to all types"
+
+    # specialisation — source was broader, specialised for this concept
+    - content: >-
+        A terminology standard provides terms, definitions, and notes.
+      sources:
+        - type: authoritative
+          status: specialisation
+          origin:
+            source: "ISO"
+            id: "10241-1"
+            version: "2011"
+          modification: "specialised from general standards to terminology"
+
+    # restyle — same content, different presentation
+    - content: >-
+        Standards are published by recognized standards bodies.
+      sources:
+        - type: lineage
+          status: restyle
+          origin:
+            text: "ISO/IEC Guide 2:2004, definition 3.2"
+
+    # unspecified — relationship to source is not classified
+    - content: >-
+        Standards evolve through periodic review and revision cycles.
+      sources:
+        - type: lineage
+          status: unspecified
+          origin:
+            text: "Wikipedia article on standardization"
+
+  # Example with its own source and locality range
+  examples:
+    - content: >-
+        ISO 9001 is an example of an international standard for quality
+        management systems.
+      sources:
+        - type: authoritative
+          status: identical
+          origin:
+            source: "ISO"
+            id: "9001"
+            version: "2015"
+            # Locality with range: reference_from → reference_to
+            locality:
+              type: clause
+              reference_from: "1"
+              reference_to: "4"
+
+  # Localized concept level sources
+  sources:
+    # Structured citation with locality (single point)
+    - type: authoritative
+      status: identical
+      origin:
+        source: "ISO"
+        id: "10241-1"
+        version: "2011"
+        clause: "3.1"
+
+    # Citation with link field
+    - type: authoritative
+      status: identical
+      origin:
+        source: "ISO"
+        id: "10241-1"
+        version: "2011"
+        link: "https://www.iso.org/standard/44798.html"
+
+    # Citation with custom_locality
+    - type: lineage
+      status: restyle
+      origin:
+        text: "ISO/IEC Guide 2:2004"
+        custom_locality:
+          - name: schema
+            value: Aec_service_life_arm
+          - name: version
+            value: "2"
+
+    # Unstructured citation (plain text)
+    - type: lineage
+      status: related
+      origin:
+        text: "ISO/IEC Guide 2:2004, definition 3.2"
+
+    # not_equal — concept meaning diverges from source
+    - type: lineage
+      status: not_equal
+      origin:
+        source: "IEC"
+        id: "60050-171"
+        version: "2019"
+      modification: "meaning diverges from IEC definition of standard"
+
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/07-sources.yaml
+++ b/spec/fixtures/concept-model-examples/v2/07-sources.yaml
@@ -1,0 +1,36 @@
+# 07 — Sources (Bibliographic Citations)
+#
+# Sources appear at managed concept level, localized concept level,
+# definition/note/example level, and designation level.
+# Each source has a type (authoritative/lineage), status, and origin citation.
+
+---
+id: "151-01-01"
+data:
+  identifier: "151-01-01"
+  localized_concepts:
+    eng: 44444444-aaaa-bbbb-cccc-dddddddddddd
+
+  # Managed concept level sources
+  sources:
+    # Authoritative source — the concept is directly from this standard
+    - type: authoritative
+      origin:
+        source: "ISO"
+        id: "10241-1"
+        version: "2011"
+        clause: "3.1"
+    # Lineage source — historical/provenance reference
+    - type: lineage
+      origin:
+        text: "ISO/IEC Guide 2:2004"
+
+  related:
+    - type: supersedes
+      ref:
+        source: "ISO"
+        id: "10241-1"
+        version: "2007"
+
+status: valid
+date_accepted: "2011-10-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/08-multilanguage-ara.yaml
+++ b/spec/fixtures/concept-model-examples/v2/08-multilanguage-ara.yaml
@@ -1,0 +1,31 @@
+# 08 — Arabic localization for 121-01-01
+#
+# Arabic uses Arab script. The entry_status field tracks this
+# localization's lifecycle independently.
+
+---
+id: 66666666-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: ara
+  script: Arab
+
+  terms:
+    - type: expression
+      designation: "مجال كهرومغناطيسي"
+      normative_status: preferred
+      language: ara
+      script: Arab
+
+  definition:
+    - content: >-
+        مجال يتحدد بشدة المجال الكهربائي وشدة المجال المغناطيسي
+
+  entry_status: valid
+  sources:
+    - type: authoritative
+      status: identical
+      origin:
+        source: "IEC"
+        id: "60050-121"
+        version: "1998"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/08-multilanguage-eng.yaml
+++ b/spec/fixtures/concept-model-examples/v2/08-multilanguage-eng.yaml
@@ -1,0 +1,29 @@
+# 08 — English localization for 121-01-01
+
+---
+id: 55555555-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  script: Latn
+
+  terms:
+    - type: expression
+      designation: "electromagnetic field"
+      normative_status: preferred
+    - type: abbreviation
+      designation: "EMF"
+      normative_status: admitted
+      acronym: true
+
+  definition:
+    - content: >-
+        field determined by the electric field strength and the magnetic
+        field strength
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-121"
+        version: "1998"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/08-multilanguage-jpn.yaml
+++ b/spec/fixtures/concept-model-examples/v2/08-multilanguage-jpn.yaml
@@ -1,0 +1,46 @@
+# 08 — Japanese localization for 121-01-01
+#
+# Japanese uses multiple scripts simultaneously. The script cascade
+# (ConceptData → Designation → Pronunciation) is demonstrated here.
+
+---
+id: 77777777-aaaa-bbbb-cccc-dddddddddddd
+data:
+  # ConceptData-level defaults
+  language_code: jpn
+  script: Hani
+
+  terms:
+    # Kanji form — uses concept-level script (Hani)
+    - type: expression
+      designation: "電磁界"
+      normative_status: preferred
+
+    # Katakana form — overrides script to Kana
+    - type: expression
+      designation: "デンジカイ"
+      normative_status: admitted
+      script: Kana
+      pronunciation:
+        - content: "denjikai"
+          language: jpn
+          script: Latn
+          system: "Var:jpn-Hrkt:Latn:Hepburn-1886"
+
+    # Latin script form — overrides script to Latn
+    - type: expression
+      designation: "denjikai"
+      normative_status: admitted
+      script: Latn
+
+  definition:
+    - content: >-
+        界は電界の強さ及び磁界の強さによって定まる場
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-121"
+        version: "1998"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/08-multilanguage-rus.yaml
+++ b/spec/fixtures/concept-model-examples/v2/08-multilanguage-rus.yaml
@@ -1,0 +1,40 @@
+# 08 — Russian localization for 121-01-01
+#
+# Russian uses Cyrl script. The conversion system (ISO 24229) can
+# specify the romanization system for transliteration.
+
+---
+id: 88888888-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: rus
+  script: Cyrl
+
+  terms:
+    - type: expression
+      designation: "электромагнитное поле"
+      normative_status: preferred
+      grammar_info:
+        - noun: true
+          number: singular
+          gender: n
+
+    # Transliterated form using ISO 24229 system code
+    - type: expression
+      designation: "elektromagnitnoye pole"
+      normative_status: admitted
+      script: Latn
+      term_type: transliterated_form
+      system: "UN:rus-Cyrl:Latn:1993"
+
+  definition:
+    - content: >-
+        поле, определяемое напряженностью электрического поля и
+        напряженностью магнитного поля
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-121"
+        version: "1998"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/08-multilanguage.yaml
+++ b/spec/fixtures/concept-model-examples/v2/08-multilanguage.yaml
@@ -1,0 +1,25 @@
+# 08 — Multi-Language & Multi-Script
+#
+# A managed concept with multiple localizations in different languages
+# and scripts. The localization map keys are ISO 639 three-character codes.
+#
+# Also demonstrates the per-designation language/script/system cascade:
+#   ConceptData defaults → Designation overrides → Pronunciation overrides
+
+---
+id: "121-01-01"
+data:
+  identifier: "121-01-01"
+  localized_concepts:
+    eng: 55555555-aaaa-bbbb-cccc-dddddddddddd
+    ara: 66666666-aaaa-bbbb-cccc-dddddddddddd
+    jpn: 77777777-aaaa-bbbb-cccc-dddddddddddd
+    rus: 88888888-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-121"
+        version: "1998"
+status: valid
+date_accepted: "1998-08-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/09-nonverbal.yaml
+++ b/spec/fixtures/concept-model-examples/v2/09-nonverbal.yaml
@@ -1,0 +1,49 @@
+# 09 — Non-Verbal Representations
+#
+# Non-verbal representations (ISO 10241-1 §6.5) are URI references to
+# external resources: images, tables, or formulas. They are NOT embedded
+# content — they reference resources that live outside the concept model.
+
+---
+id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "Nyquist plot"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        a polar plot of the frequency response of a system, used in control
+        theory to assess stability
+
+  # Non-verbal representations referenced by URI
+  non_verbal_rep:
+    # Image — relative path within the GCR package
+    - type: image
+      ref: "assets/nyquist-plot.svg"
+      text: "Nyquist plot for a typical second-order system"
+      sources:
+        - type: authoritative
+          origin:
+            text: "IEC 60050-351"
+
+    # Table — URN reference
+    - type: table
+      ref: "urn:gcr:assets:stability-criteria-table"
+      text: "Comparison of stability criteria"
+
+    # Formula — URL reference
+    - type: formula
+      ref: "https://example.org/formulas/nyquist-criterion"
+      text: "Nyquist stability criterion formula"
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-351"
+        version: "2013"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/10-concept-reference-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/10-concept-reference-localized.yaml
@@ -1,0 +1,42 @@
+# 10 — Concept References (Localized)
+#
+# The references field on LocalizedConcept holds ConceptReference objects
+# for typed cross-references within concept data.
+
+---
+id: aaaaaaaa-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "insulating material"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        material used to prevent the flow of electric current
+
+  # Typed references to other concepts
+  references:
+    # Local reference — concept in the same glossary
+    - concept_id: "212-01-02"
+      ref_type: "local"
+      term: "insulation"
+
+    # External reference — concept in another registry (URN)
+    - urn: "urn:iso:std:iso:10241:term:3.1.1"
+      ref_type: "urn"
+
+    # Designation reference — points to a specific designation
+    - concept_id: "212-05-03"
+      ref_type: "designation"
+      term: "dielectric strength"
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-212"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/10-concept-reference.yaml
+++ b/spec/fixtures/concept-model-examples/v2/10-concept-reference.yaml
@@ -1,0 +1,33 @@
+# 10 — Concept References
+#
+# ConceptReference is a typed reference to another concept — either local
+# (within the same glossary) or external (in another registry).
+# Used for domain assignments, concept mentions, and cross-references.
+
+---
+id: "212-01-01"
+data:
+  identifier: "212-01-01"
+  localized_concepts:
+    eng: aaaaaaaa-aaaa-bbbb-cccc-dddddddddddd
+
+  # Domains demonstrate ConceptReference with ref_type "domain"
+  domains:
+    # Local reference — concept_id only, source indicates the registry
+    - concept_id: "212"
+      source: "urn:iec:std:iec:60050"
+      ref_type: "domain"
+    - concept_id: "212-01"
+      source: "urn:iec:std:iec:60050"
+      ref_type: "domain"
+
+  # ConceptReference also appears in LocalizedConcept.data.references
+  # for typed cross-references (see localized companion file)
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-212"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/11-lifecycle-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/11-lifecycle-localized.yaml
@@ -1,0 +1,64 @@
+# 11 — Lifecycle & Review (Localized)
+#
+# Localized concepts have their own entry_status, dates, and review metadata.
+# A localization can be retired while the managed concept remains valid.
+# Also demonstrates classification and review_type fields.
+
+---
+id: bbbbbbbb-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  # Entry status of this specific localization
+  entry_status: valid
+
+  terms:
+    - type: expression
+      designation: "oscillation"
+      normative_status: preferred
+      grammar_info:
+        - noun: true
+
+  definition:
+    - content: >-
+        the variation, usually with time, of the magnitude of a quantity with
+        respect to a specified reference
+
+  # Localization-level dates
+  dates:
+    - date: "1992-03-01T00:00:00+00:00"
+      type: accepted
+    - date: "2016-08-01T00:00:00+00:00"
+      type: amended
+
+  # Review metadata
+  review_date: "2019-06-01T00:00:00+00:00"
+  review_decision_date: "2019-09-01T00:00:00+00:00"
+  review_decision_event: "published"
+
+  # Lineage similarity — how close this entry is to the source
+  lineage_source_similarity: 95
+
+  # Release version
+  release: "2.1"
+
+  sources:
+    - type: authoritative
+      status: identical
+      origin:
+        source: "IEC"
+        id: "60050-702"
+        version: "1992"
+    - type: lineage
+      status: similar
+      origin:
+        text: "IEC 60050-702:1988"
+
+# Classification of this localized concept within the glossary
+classification: "admitted"
+
+# Review type applied to this localized concept
+review_type: "editorial"
+
+status: valid
+date_accepted: "1992-03-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/11-lifecycle.yaml
+++ b/spec/fixtures/concept-model-examples/v2/11-lifecycle.yaml
@@ -1,0 +1,37 @@
+# 11 — Lifecycle & Review
+#
+# Managed concepts and localizations have lifecycle metadata:
+# status, dates, review information.
+
+---
+id: "702-01-01"
+data:
+  identifier: "702-01-01"
+  localized_concepts:
+    eng: bbbbbbbb-aaaa-bbbb-cccc-dddddddddddd
+
+  # Structured dates (alternative to simplified date_accepted at top level)
+  dates:
+    - date: "1992-03-01T00:00:00+00:00"
+      type: accepted
+    - date: "2016-08-01T00:00:00+00:00"
+      type: amended
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-702"
+        version: "1992"
+
+  # This concept supersedes an older entry
+  related:
+    - type: supersedes
+      ref:
+        source: "IEC"
+        id: "60050-702"
+        version: "1988"
+
+# Concept lifecycle status
+status: valid
+date_accepted: "1992-03-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/12-absent-designation-eng.yaml
+++ b/spec/fixtures/concept-model-examples/v2/12-absent-designation-eng.yaml
@@ -1,0 +1,27 @@
+# 12 — English: normal designation
+
+---
+id: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "kilogram"
+      normative_status: preferred
+    - type: symbol
+      designation: "kg"
+      normative_status: admitted
+      international: true
+
+  definition:
+    - content: >-
+        SI unit of mass
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/12-absent-designation-jpn.yaml
+++ b/spec/fixtures/concept-model-examples/v2/12-absent-designation-jpn.yaml
@@ -1,0 +1,50 @@
+# 12 — Japanese: absent designation for expression, international symbol shared
+#
+# Japanese may not have a native expression for some technical terms.
+# The `absent` flag makes this explicit. The international symbol (kg)
+# is still used — it has `international: true` and no language override,
+# so it applies across all localizations.
+
+---
+id: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: jpn
+  script: Hani
+
+  terms:
+    # No native Japanese expression exists — explicitly marked absent
+    - type: expression
+      designation: null
+      absent: true
+      language: eng
+      script: Latn
+
+    # The international symbol is shared — no language override needed
+    - type: symbol
+      designation: "kg"
+      normative_status: admitted
+      international: true
+
+    # Japanese uses a transliterated form
+    - type: expression
+      designation: "キログラム"
+      normative_status: admitted
+      script: Kana
+      term_type: transliterated_form
+      pronunciation:
+        - content: "kiriguramu"
+          language: jpn
+          script: Latn
+          system: "Var:jpn-Hrkt:Latn:Hepburn-1886"
+
+  definition:
+    - content: >-
+        質量のSI単位
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/12-absent-designation.yaml
+++ b/spec/fixtures/concept-model-examples/v2/12-absent-designation.yaml
@@ -1,0 +1,19 @@
+# 12 — Absent Designation & International Symbols
+#
+# The `absent` flag indicates no equivalent designation exists in this language.
+# The `international` flag indicates a symbol valid across all languages.
+
+---
+id: "112-02-01"
+data:
+  identifier: "112-02-01"
+  localized_concepts:
+    eng: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+    jpn: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated-localized.yaml
@@ -1,0 +1,50 @@
+# 13 — Superseded & Deprecated (Localized)
+#
+# The localized concept for a superseded entry. Shows deprecated
+# normative_status on designations and entry_status transitions.
+
+---
+id: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  # Entry status reflects superseded state
+  entry_status: superseded
+
+  terms:
+    # The preferred term is now deprecated
+    - type: expression
+      designation: "quantity"
+      normative_status: deprecated
+      grammar_info:
+        - noun: true
+          number: singular
+
+    # Superseded by this preferred term in the newer entry
+    - type: expression
+      designation: "kind of quantity"
+      normative_status: superseded
+      term_type: full_form
+
+  definition:
+    - content: >-
+        property of a phenomenon, body, or substance, where the property
+        has a magnitude that can be expressed as a number and a reference
+      sources:
+        - type: authoritative
+          status: identical
+          origin:
+            source: "IEC"
+            id: "60050-112"
+            version: "2010"
+
+  dates:
+    - date: "2010-01-01T00:00:00+00:00"
+      type: accepted
+    - date: "2023-06-01T00:00:00+00:00"
+      type: retired
+
+  release: "1.0"
+
+status: superseded
+date_accepted: "2010-01-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated.yaml
+++ b/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated.yaml
@@ -1,0 +1,44 @@
+# 13 — Superseded & Deprecated Concept Lifecycle
+#
+# Demonstrates the deprecated/superseded lifecycle: a concept that was
+# replaced by a newer entry. Shows superseded_by at the managed level,
+# deprecated normative_status on designations, and retired dates.
+#
+# Companion: 13-superseded-deprecated-localized.yaml
+
+---
+id: "112-01-02"
+data:
+  identifier: "112-01-02"
+  localized_concepts:
+    eng: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+
+# This concept is superseded — replaced by a newer entry
+related:
+  - type: superseded_by
+    content: "replaced by updated definition"
+    ref:
+      source: "IEC"
+      id: "112-01-03"
+
+  - type: deprecates
+    content: "deprecated older entry"
+    ref:
+      source: "IEC"
+      id: "112-01-01"
+
+# Concept lifecycle status: superseded
+status: superseded
+
+dates:
+  - date: "2010-01-01T00:00:00+00:00"
+    type: accepted
+  - date: "2023-06-01T00:00:00+00:00"
+    type: retired

--- a/spec/fixtures/concept-model-examples/v2/14-term-types.yaml
+++ b/spec/fixtures/concept-model-examples/v2/14-term-types.yaml
@@ -1,0 +1,193 @@
+# 14 — ISO 12620 Term Types
+#
+# ISO 12620 / TBX term_type classification for designations. The term_type
+# attribute categorizes a designation with respect to how it is formed or
+# where/how it is used.
+#
+# Categories:
+#   Orthographic/structural: abbreviation, acronym, clipped_term, full_form,
+#     initialism, short_form, transliterated_form, transcribed_form, variant
+#   Symbolic/formulaic: equation, formula, logical_expression, symbol
+#   Usage/provenance: common_name, entry_term, internationalism,
+#     international_scientific_term, part_number, phraseological_unit,
+#     shortcut, sku, standard_text, synonym, synonymous_phrase
+
+---
+id: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    # ── Orthographic / Structural ────────────────────────────────────────
+
+    # full_form — the complete, unabbreviated form (default for expressions)
+    - type: expression
+      designation: "World Health Organization"
+      normative_status: preferred
+      term_type: full_form
+
+    # abbreviation — generic shortened form
+    - type: abbreviation
+      designation: "WHO"
+      normative_status: admitted
+      acronym: true
+      term_type: abbreviation
+
+    # acronym — pronounced as a word
+    - type: abbreviation
+      designation: "laser"
+      normative_status: admitted
+      acronym: true
+      term_type: acronym
+
+    # initialism — each letter pronounced separately
+    - type: abbreviation
+      designation: "DNA"
+      normative_status: admitted
+      initialism: true
+      term_type: initialism
+
+    # clipped_term — shortened by removing part of the word
+    - type: expression
+      designation: "phone"
+      normative_status: admitted
+      term_type: clipped_term
+
+    # short_form — any recognized short form
+    - type: expression
+      designation: "app"
+      normative_status: admitted
+      term_type: short_form
+
+    # variant — regional or stylistic variant
+    - type: expression
+      designation: "catalog"
+      normative_status: admitted
+      geographical_area: US
+      term_type: variant
+
+    # transliterated_form — converted from one script to another, letter by letter
+    - type: expression
+      designation: "elektromagnitnoye pole"
+      normative_status: admitted
+      language: rus
+      script: Latn
+      system: "UN:rus-Cyrl:Latn:1993"
+      term_type: transliterated_form
+
+    # transcribed_form — converted from one script to another, phonetically
+    - type: expression
+      designation: "Tōkyō"
+      normative_status: admitted
+      language: jpn
+      script: Latn
+      system: "Var:jpn-Hrkt:Latn:Hepburn-1886"
+      term_type: transcribed_form
+
+    # ── Symbolic / Formulaic ─────────────────────────────────────────────
+
+    # symbol — a non-letter symbol designation
+    - type: symbol
+      designation: "Ω"
+      normative_status: preferred
+      international: true
+      term_type: symbol
+
+    # formula — a mathematical or chemical formula
+    - type: expression
+      designation: "H₂O"
+      normative_status: admitted
+      term_type: formula
+
+    # logical_expression
+    - type: expression
+      designation: "A ∧ B"
+      normative_status: admitted
+      term_type: logical_expression
+
+    # equation — a mathematical equation as a designation
+    - type: expression
+      designation: "E = mc²"
+      normative_status: admitted
+      term_type: equation
+
+    # ── Usage / Provenance ───────────────────────────────────────────────
+
+    # common_name — everyday name for a scientific concept
+    - type: expression
+      designation: "water"
+      normative_status: admitted
+      term_type: common_name
+
+    # entry_term — the term as it appears in a specific entry/listing
+    - type: expression
+      designation: "dihydrogen monoxide"
+      normative_status: admitted
+      term_type: entry_term
+
+    # internationalism — word shared across many languages
+    - type: expression
+      designation: "computer"
+      normative_status: admitted
+      term_type: internationalism
+
+    # international_scientific_term — internationally recognized scientific term
+    - type: expression
+      designation: "photosynthesis"
+      normative_status: admitted
+      term_type: international_scientific_term
+
+    # synonym — a true synonym of the preferred term
+    - type: expression
+      designation: "liquid hydrogen oxide"
+      normative_status: admitted
+      term_type: synonym
+
+    # synonymous_phrase — a phrasal synonym
+    - type: expression
+      designation: "oxidane"
+      normative_status: admitted
+      term_type: synonymous_phrase
+
+    # part_number — a part or component identifier
+    - type: expression
+      designation: "47kΩ resistor"
+      normative_status: admitted
+      term_type: part_number
+
+    # phraseological_unit — a fixed expression or collocation
+    - type: expression
+      designation: "standard atmospheric pressure"
+      normative_status: admitted
+      term_type: phraseological_unit
+
+    # shortcut — a commonly used shortcut reference
+    - type: expression
+      designation: "spec"
+      normative_status: admitted
+      term_type: shortcut
+
+    # sku — stock keeping unit identifier
+    - type: expression
+      designation: "SKU-2024-BLK-M"
+      normative_status: admitted
+      term_type: sku
+
+    # standard_text — boilerplate or standardized text
+    - type: expression
+      designation: "Not applicable"
+      normative_status: admitted
+      term_type: standard_text
+
+  definition:
+    - content: >-
+        comprehensive example demonstrating all ISO 12620 term type
+        classifications across orthographic, symbolic, and usage categories
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "ISO"
+        id: "12620"
+        version: "2019"
+status: valid

--- a/spec/fixtures/concept-model-examples/v2/15-citation-features.yaml
+++ b/spec/fixtures/concept-model-examples/v2/15-citation-features.yaml
@@ -1,0 +1,141 @@
+# 15 — Citation & Locality Features
+#
+# Demonstrates all citation and locality features:
+# - Structured citation (source + id + version)
+# - Unstructured citation (plain text)
+# - Locality with single reference (clause, section, page)
+# - Locality with range (reference_from → reference_to)
+# - Custom locality (name-value pairs)
+# - Link field (URL to source document)
+# - Clause shorthand
+# - Original field
+
+---
+id: eeeeeeee-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "quality management"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        coordinated activities to direct and control an organization with
+        regard to quality
+      sources:
+        # Structured citation with clause locality (single point)
+        - type: authoritative
+          status: identical
+          origin:
+            source: "ISO"
+            id: "9000"
+            version: "2015"
+            clause: "3.3.3"
+
+    - content: >-
+        the aspect of overall management that determines and implements
+        quality policy
+      sources:
+        # Locality range: clause 3.3.3 through 3.3.5
+        - type: authoritative
+          status: modified
+          origin:
+            source: "ISO"
+            id: "8402"
+            version: "1994"
+            locality:
+              type: clause
+              reference_from: "3.3.3"
+              reference_to: "3.3.5"
+          modification: "updated from 1994 terminology"
+
+  notes:
+    - content: >-
+        Quality management includes quality planning, quality control,
+        quality assurance, and quality improvement.
+      sources:
+        # Citation with link field
+        - type: authoritative
+          status: identical
+          origin:
+            source: "ISO"
+            id: "9000"
+            version: "2015"
+            link: "https://www.iso.org/standard/45481.html"
+            locality:
+              type: section
+              reference_from: "2.2"
+
+    - content: >-
+        The concept of quality management was significantly influenced
+        by the work of Deming and Juran.
+      sources:
+        # Unstructured citation (plain text)
+        - type: lineage
+          status: related
+          origin:
+            text: "Deming, W.E., Out of the Crisis, MIT Press, 1986"
+
+    - content: >-
+        Quality management frameworks may use custom schema versioning.
+      sources:
+        # Citation with custom_locality
+        - type: lineage
+          status: context_added
+          origin:
+            text: "Internal quality manual QM-2024"
+            custom_locality:
+              - name: schema
+                value: QMS_Framework_v3
+              - name: version
+                value: "3"
+              - name: department
+                value: engineering
+
+    - content: >-
+        This definition was adapted from an earlier standard.
+      sources:
+        # Citation with original field (transitional)
+        - type: lineage
+          status: restyle
+          origin:
+            text: "ISO 8402:1986, quality management"
+            original: "ISO/TC 176 document N45"
+
+    - content: >-
+        Page-range reference using locality.
+      sources:
+        # Locality range: pages 42-47
+        - type: authoritative
+          status: similar
+          origin:
+            source: "ISO"
+            id: "9000"
+            version: "2005"
+            locality:
+              type: page
+              reference_from: "42"
+              reference_to: "47"
+
+  sources:
+    # Multiple locality types on the concept source
+    - type: authoritative
+      status: identical
+      origin:
+        source: "ISO"
+        id: "9001"
+        version: "2015"
+        link: "https://www.iso.org/standard/62085.html"
+        locality:
+          type: annex
+          reference_from: "A"
+
+    - type: lineage
+      status: unspecified
+      origin:
+        text: "Juran, J.M., Quality Control Handbook, McGraw-Hill, 1951"
+        link: "https://archive.org/details/qualitycontrolha00jura"
+
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/01-minimal-concept.yaml
+++ b/spec/fixtures/concept-model-examples/v3/01-minimal-concept.yaml
@@ -1,0 +1,20 @@
+# 01 — Minimal Concept
+#
+# The smallest valid managed concept: an id, a localization map, and status.
+# Demonstrates identity, localization map, and lifecycle metadata.
+---
+id: 113-01-01
+data:
+  identifier: 113-01-01
+  uri: urn:iec:std:iec:60050-113-01-01
+  localized_concepts:
+    eng: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-113
+        version: '2011'
+status: valid
+date_accepted: '2011-04-01T00:00:00+00:00'

--- a/spec/fixtures/concept-model-examples/v3/01-minimal-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/01-minimal-localized.yaml
@@ -1,0 +1,21 @@
+# 01 — Minimal Localized Concept
+#
+# The smallest valid localized concept: id, language, term, definition, source.
+---
+id: a1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: length
+    normative_status: preferred
+  definition:
+  - content: distance between two points
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-113
+        version: '2011'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/02-designation-abbreviation.yaml
+++ b/spec/fixtures/concept-model-examples/v3/02-designation-abbreviation.yaml
@@ -1,0 +1,40 @@
+# 02 — Designation: Abbreviation
+#
+# Abbreviation designations extend Expression with type booleans:
+# acronym, initialism, truncation. Also supports designation-level relationships.
+---
+id: c1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: Light Emitting Diode
+    normative_status: preferred
+  - type: abbreviation
+    designation: LED
+    normative_status: admitted
+    acronym: true
+    related:
+    - type: abbreviated_form_for
+      target: Light Emitting Diode
+  - type: abbreviation
+    designation: HTML
+    normative_status: admitted
+    initialism: true
+  - type: abbreviation
+    designation: app
+    normative_status: admitted
+    truncation: true
+    related:
+    - type: short_form_for
+      target: application
+  definition:
+  - content: a semiconductor device that emits light when current flows through it
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-521
+        version: '2002'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/02-designation-expression.yaml
+++ b/spec/fixtures/concept-model-examples/v3/02-designation-expression.yaml
@@ -1,0 +1,99 @@
+# 02 — Designation: Expression
+#
+# Expression designations are words or phrases — the most common type.
+# Shows normative_status, grammar_info, usage_info, field_of_application,
+# term_type (ISO 12620), and designation-level sources.
+---
+id: b1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: color
+    normative_status: preferred
+    geographical_area: US
+    grammar_info:
+    - noun: true
+      number: singular
+    term_type: full_form
+  - type: expression
+    designation: colour
+    normative_status: admitted
+    geographical_area: GB
+    grammar_info:
+    - noun: true
+      number: singular
+    term_type: variant
+  - type: expression
+    designation: colour signal
+    normative_status: deprecated
+    usage_info: television
+    field_of_application: in analogue television
+    grammar_info:
+    - noun: true
+      number: singular
+    term_type: entry_term
+  - type: expression
+    designation: to color
+    normative_status: admitted
+    grammar_info:
+    - verb: true
+    term_type: full_form
+  - type: expression
+    designation: colorful
+    normative_status: admitted
+    grammar_info:
+    - adj: true
+      gender:
+      - m
+      - f
+      number: plural
+  - type: expression
+    designation: colorfully
+    normative_status: admitted
+    grammar_info:
+    - adverb: true
+  - type: expression
+    designation: coloring
+    normative_status: admitted
+    grammar_info:
+    - participle: true
+  - type: expression
+    designation: in color
+    normative_status: admitted
+    grammar_info:
+    - preposition: true
+  - type: expression
+    designation: color
+    normative_status: admitted
+    prefix: non-
+    usage_info: pigment chemistry
+  - type: expression
+    designation: sun
+    normative_status: admitted
+    term_type: common_name
+  - type: expression
+    designation: hue
+    normative_status: admitted
+    term_type: synonym
+  - type: expression
+    designation: chromatic
+    normative_status: admitted
+    sources:
+    - type: authoritative
+      status: identical
+      origin:
+        ref:
+          source: IEC
+          id: 60050-845
+          version: '2020'
+  definition:
+  - content: visual sensation produced by light of a specific wavelength
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-845
+        version: '2020'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/02-designation-symbol.yaml
+++ b/spec/fixtures/concept-model-examples/v3/02-designation-symbol.yaml
@@ -1,0 +1,35 @@
+# 02 — Designation: Symbol, Letter Symbol, Graphical Symbol
+#
+# Three symbol designation types, each inheriting from Base.
+# Symbols are often international (valid across languages).
+---
+id: d1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+  terms:
+  - type: symbol
+    designation: Ω
+    normative_status: preferred
+    international: true
+  - type: letter_symbol
+    designation: R
+    text: R
+    normative_status: admitted
+    international: true
+  - type: graphical_symbol
+    designation: warning sign
+    text: general warning
+    image: "⚠"
+    normative_status: preferred
+    international: true
+  definition:
+  - content: a designation that is not a word or an abbreviation, used to represent
+      a concept in a given language
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: ISO
+        id: 10241-1
+        version: '2011'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/03-pronunciation.yaml
+++ b/spec/fixtures/concept-model-examples/v3/03-pronunciation.yaml
@@ -1,0 +1,40 @@
+# 03 — Pronunciation & Per-Designation Language Overrides
+#
+# Pronunciations attach to individual designations. Each pronunciation entry
+# can specify its own language, script, country, and transcription system.
+# Designations can also override the concept-level language/script/system.
+---
+id: e1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: jpn
+  script: Hani
+  terms:
+  - type: expression
+    designation: 東京
+    normative_status: preferred
+    pronunciation:
+    - content: Tōkyō
+      language: jpn
+      script: Latn
+      system: Var:jpn-Hrkt:Latn:Hepburn-1886
+    - content: toːkjoː
+      language: jpn
+      script: Latn
+      system: IPA
+  - type: expression
+    designation: とうきょう
+    normative_status: admitted
+    script: Hrkt
+    pronunciation:
+    - content: Tōkyō
+      language: jpn
+      script: Latn
+      system: Var:jpn-Hrkt:Latn:Hepburn-1886
+  definition:
+  - content: capital city of Japan
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: Example pronunciation data
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/04-definition-notes-examples.yaml
+++ b/spec/fixtures/concept-model-examples/v3/04-definition-notes-examples.yaml
@@ -1,0 +1,47 @@
+# 04 — Definition, Notes, and Examples
+#
+# Definitions, notes, and examples all use DetailedDefinition —
+# text content with optional per-item sources.
+---
+id: f1b2c3d4-e5f6-7890-abcd-ef1234567890
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: resistance
+    normative_status: preferred
+    grammar_info:
+    - noun: true
+  - type: symbol
+    designation: R
+    normative_status: admitted
+    international: true
+  definition:
+  - content: quotient of the voltage and the current in a conductor at a given temperature
+    sources:
+    - type: authoritative
+      origin:
+        ref:
+          source: IEC
+          id: 60050-131
+          version: '2002'
+  notes:
+  - content: Resistance is a property of a conductor and depends on its dimensions,
+      material, and temperature.
+  - content: The SI unit of resistance is the ohm (Ω).
+    sources:
+    - type: lineage
+      origin:
+        ref:
+          source: SI Brochure, 9th edition
+  examples:
+  - content: A copper wire 1 m long with a cross-section of 1 mm² has a resistance
+      of approximately 0.017 Ω at 20 °C.
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-131
+        version: '2002'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/05-domains-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/05-domains-localized.yaml
@@ -1,0 +1,24 @@
+# 05 — Domains (Localized): per-language domain URI
+#
+# LocalizedConcept.data.domain is a simple URI string.
+# It can be relative, a URN, or an HTTP URL.
+---
+id: 11111111-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  domain: urn:iec:std:iec:60050-103-01
+  terms:
+  - type: expression
+    designation: functional
+    normative_status: preferred
+  definition:
+  - content: relating to a correspondence that associates uniquely to each element
+      of a set an element of another set
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-103
+        version: '2009'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/05-domains.yaml
+++ b/spec/fixtures/concept-model-examples/v3/05-domains.yaml
@@ -1,0 +1,27 @@
+# 05 — Domains (Classification)
+#
+# Domains classify a concept into subject areas — language-agnostic tags.
+# ManagedConcept.data.domains is a ConceptReference array with ref_type "domain".
+# LocalizedConcept.data.domain is a per-language URI string.
+---
+id: 103-01-02
+data:
+  identifier: 103-01-02
+  localized_concepts:
+    eng: 11111111-aaaa-bbbb-cccc-dddddddddddd
+  domains:
+  - concept_id: '103'
+    source: urn:iec:std:iec:60050
+    ref_type: domain
+  - concept_id: 103-01
+    source: urn:iec:std:iec:60050
+    ref_type: domain
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-103
+        version: '2009'
+status: valid
+date_accepted: '2009-12-14T00:00:00+00:00'

--- a/spec/fixtures/concept-model-examples/v3/06-related-localized-fra.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-localized-fra.yaml
@@ -1,0 +1,31 @@
+# 06 — Related Concepts (French — false_friend)
+#
+# The French variant has a `false_friend` relationship (ISO 12620/TBX)
+# that the English variant does not. This demonstrates language-specific
+# relationships.
+---
+id: 33333333-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: fra
+  terms:
+  - type: expression
+    designation: mesure
+    normative_status: preferred
+    grammar_info:
+    - gender: f
+      number: singular
+  definition:
+  - content: ensemble d'opérations ayant pour but de déterminer la valeur d'une grandeur
+  related:
+  - type: false_friend
+    content: measure (English, musical sense)
+    ref:
+      text: measure
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-112
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/06-related-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-localized.yaml
@@ -1,0 +1,30 @@
+# 06 — Related Concepts (Language-Specific)
+#
+# LocalizedConcept.data.related holds relationships that only exist in
+# one language variant. For example, French "mesure" has a false_friend
+# relationship that English "measurement" does not.
+---
+id: 22222222-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: system
+    normative_status: preferred
+  definition:
+  - content: set of interrelated elements considered in a defined context as a whole
+      and separated from their environment
+  related:
+  - type: see
+    content: open system
+    ref:
+      source: IEC
+      id: 102-03-05
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-102
+        version: '2007'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/06-related-relationships.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-relationships.yaml
@@ -1,0 +1,208 @@
+# 06 — Related Concepts (All 32 Typed Semantic Relationships)
+#
+# Relationships are typed semantic links between concepts, spanning:
+# - ISO 10241-1: lifecycle (deprecates, supersedes, superseded_by),
+#   comparative (compare, contrast), associative (see)
+# - ISO 25964 / SKOS: hierarchical (broader, narrower) with generic/
+#   partitive/instantial subtypes, equivalence (equivalent, exact_match),
+#   approximate mapping (close_match, broad_match, narrow_match,
+#   related_match)
+# - ISO 12620 / TBX: associative subtypes (related_concept,
+#   related_concept_broader, related_concept_narrower),
+#   spatiotemporal (sequentially_related_concept, spatially_related_concept,
+#   temporally_related_concept), lexical (homograph, false_friend)
+#
+# false_friend and language-specific relationships are demonstrated
+# in the localized companion files.
+
+---
+id: "102-03-01"
+data:
+  identifier: "102-03-01"
+  localized_concepts:
+    eng: 22222222-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-102"
+        version: "2007"
+
+related:
+  # ── Hierarchical (ISO 10241-1 / ISO 25964 BT/NT) ──────────────────────
+  - type: broader
+    content: "complex system"
+    ref:
+      source: "IEC"
+      id: "102-03-02"
+
+  - type: narrower
+    content: "subsystem"
+    ref:
+      source: "IEC"
+      id: "102-03-03"
+
+  # ── ISO 25964 Generic Hierarchy (BTG/NTG) ─────────────────────────────
+  # "is a kind of" — generic/specific relationship
+  - type: broader_generic
+    content: "physical system"
+    ref:
+      source: "IEC"
+      id: "102-01-01"
+
+  - type: narrower_generic
+    content: "closed system"
+    ref:
+      source: "IEC"
+      id: "102-03-04"
+
+  # ── ISO 25964 Partitive Hierarchy (BTP/NTP) ───────────────────────────
+  # "is a part of" — whole/part relationship (transitive)
+  - type: broader_partitive
+    content: "larger assembly"
+    ref:
+      source: "IEC"
+      id: "102-05-01"
+
+  - type: narrower_partitive
+    content: "system component"
+    ref:
+      source: "IEC"
+      id: "102-05-02"
+
+  # ── ISO 25964 Instantial Hierarchy (BTI/NTI) ───────────────────────────
+  # "is an instance of" — class/instance relationship
+  - type: broader_instantial
+    content: "thermodynamic system (class)"
+    ref:
+      source: "IEC"
+      id: "102-06-01"
+
+  - type: narrower_instantial
+    content: "specific Carnot engine"
+    ref:
+      source: "IEC"
+      id: "102-06-02"
+
+  # ── Equivalence (ISO 10241-1 / ISO 25964 / SKOS) ───────────────────────
+  - type: equivalent
+    content: "system (general systems theory)"
+    ref:
+      source: "ISO"
+      id: "10241-1"
+
+  - type: exact_match
+    content: "exact cross-vocabulary match (SKOS skos:exactMatch)"
+    ref:
+      source: "VIM"
+      id: "JCGM-200"
+
+  # ── SKOS Mapping Properties ───────────────────────────────────────────
+  - type: close_match
+    ref:
+      text: "system (general systems theory)"
+
+  - type: broad_match
+    content: "related broader concept in another vocabulary"
+    ref:
+      source: "ISO"
+      id: "1087-1"
+
+  - type: narrow_match
+    content: "related narrower concept in another vocabulary"
+    ref:
+      source: "ISO"
+      id: "1087-2"
+
+  - type: related_match
+    content: "related concept in another vocabulary"
+    ref:
+      source: "IEC"
+      id: "60050-151"
+
+  # ── Comparative (ISO 10241-1) ─────────────────────────────────────────
+  - type: compare
+    content: "closed system"
+    ref:
+      source: "IEC"
+      id: "102-03-04"
+
+  - type: contrast
+    content: "environment"
+    ref:
+      source: "IEC"
+      id: "102-03-06"
+
+  # ── Associative (ISO 10241-1 / ISO 25964 RT) ─────────────────────────
+  - type: see
+    content: "open system"
+    ref:
+      source: "IEC"
+      id: "102-03-05"
+
+  # ── Associative Subtypes (ISO 25964 / TBX) ────────────────────────────
+  - type: related_concept
+    content: "boundary of a system"
+    ref:
+      source: "IEC"
+      id: "102-04-01"
+
+  - type: related_concept_broader
+    content: "system boundary (broader sense)"
+    ref:
+      source: "IEC"
+      id: "102-04-02"
+
+  - type: related_concept_narrower
+    content: "permeable boundary (narrower sense)"
+    ref:
+      source: "IEC"
+      id: "102-04-03"
+
+  # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
+  - type: sequentially_related_concept
+    content: "next process step"
+    ref:
+      source: "IEC"
+      id: "102-07-01"
+
+  - type: spatially_related_concept
+    content: "adjacent region"
+    ref:
+      source: "IEC"
+      id: "102-07-02"
+
+  - type: temporally_related_concept
+    content: "preceding state"
+    ref:
+      source: "IEC"
+      id: "102-07-03"
+
+  # ── Lifecycle (ISO 10241-1) ───────────────────────────────────────────
+  - type: supersedes
+    ref:
+      source: "IEC"
+      id: "102-03-00"
+
+  - type: superseded_by
+    content: "replaced by newer concept"
+    ref:
+      source: "IEC"
+      id: "102-03-10"
+
+  - type: deprecates
+    content: "old deprecated term"
+    ref:
+      source: "IEC"
+      id: "102-03-11"
+
+  # ── Lexical (ISO 12620 / TBX) ─────────────────────────────────────────
+  # false_friend is language-specific — see 06-related-localized-fra.yaml
+  - type: homograph
+    content: "same spelling, different meaning"
+    ref:
+      source: "IEC"
+      id: "102-08-01"
+
+status: valid
+date_accepted: "2007-08-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v3/07-sources-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/07-sources-localized.yaml
@@ -1,0 +1,148 @@
+# 07 — Sources (Localized — all source features)
+#
+# Comprehensive demonstration of sources and citations at all levels:
+# localized concept, definition, note, example, and designation.
+# Shows all source status values, citation locality features
+# (ranges, custom_locality, link), and modification notes.
+---
+id: 44444444-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: standard
+    normative_status: preferred
+    sources:
+    - type: authoritative
+      status: identical
+      origin:
+        ref:
+          source: ISO
+          id: 10241-1
+          version: '2011'
+  definition:
+  - content: a document established by consensus and approved by a recognized body
+      that provides rules, guidelines or characteristics
+    sources:
+    - type: authoritative
+      status: modified
+      origin:
+        ref:
+          source: ISO
+          id: 10241-1
+          version: '2011'
+        locality:
+          type: clause
+          reference_from: '3.1'
+      modification: replaced "for common and repeated use" with broader wording
+  notes:
+  - content: Standards include but are not limited to international standards, regional
+      standards, and national standards.
+    sources:
+    - type: lineage
+      status: similar
+      origin:
+        ref:
+          source: ISO/IEC Guide 2
+  - content: The term "standard" also applies to de facto standards that arise through
+      widespread adoption.
+    sources:
+    - type: lineage
+      status: context_added
+      origin:
+        ref:
+          source: ISO
+          id: IEC Guide 2
+          version: '2004'
+  - content: Standards may cover products, processes, or services.
+    sources:
+    - type: authoritative
+      status: generalisation
+      origin:
+        ref:
+          source: ISO
+          id: 10241-1
+          version: '2011'
+      modification: generalised from product standards to all types
+  - content: A terminology standard provides terms, definitions, and notes.
+    sources:
+    - type: authoritative
+      status: specialisation
+      origin:
+        ref:
+          source: ISO
+          id: 10241-1
+          version: '2011'
+      modification: specialised from general standards to terminology
+  - content: Standards are published by recognized standards bodies.
+    sources:
+    - type: lineage
+      status: restyle
+      origin:
+        ref:
+          source: ISO/IEC Guide 2:2004, definition 3.2
+  - content: Standards evolve through periodic review and revision cycles.
+    sources:
+    - type: lineage
+      status: unspecified
+      origin:
+        ref:
+          source: Wikipedia article on standardization
+  examples:
+  - content: ISO 9001 is an example of an international standard for quality management
+      systems.
+    sources:
+    - type: authoritative
+      status: identical
+      origin:
+        locality:
+          type: clause
+          reference_from: '1'
+          reference_to: '4'
+        ref:
+          source: ISO
+          id: '9001'
+          version: '2015'
+  sources:
+  - type: authoritative
+    status: identical
+    origin:
+      ref:
+        source: ISO
+        id: 10241-1
+        version: '2011'
+      locality:
+        type: clause
+        reference_from: '3.1'
+  - type: authoritative
+    status: identical
+    origin:
+      link: https://www.iso.org/standard/44798.html
+      ref:
+        source: ISO
+        id: 10241-1
+        version: '2011'
+  - type: lineage
+    status: restyle
+    origin:
+      custom_locality:
+      - name: schema
+        value: Aec_service_life_arm
+      - name: version
+        value: '2'
+      ref:
+        source: ISO/IEC Guide 2:2004
+  - type: lineage
+    status: related
+    origin:
+      ref:
+        source: ISO/IEC Guide 2:2004, definition 3.2
+  - type: lineage
+    status: not_equal
+    origin:
+      ref:
+        source: IEC
+        id: 60050-171
+        version: '2019'
+    modification: meaning diverges from IEC definition of standard
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/07-sources.yaml
+++ b/spec/fixtures/concept-model-examples/v3/07-sources.yaml
@@ -1,0 +1,40 @@
+# 07 — Sources (Bibliographic Citations)
+#
+# Sources appear at managed concept level, localized concept level,
+# definition/note/example level, and designation level.
+# Each source has a type (authoritative/lineage), status, and origin citation.
+# V3 format: origin.ref is always a hash { source, id, version? }.
+
+---
+id: "151-01-01"
+data:
+  identifier: "151-01-01"
+  localized_concepts:
+    eng: 44444444-aaaa-bbbb-cccc-dddddddddddd
+
+  # Managed concept level sources
+  sources:
+    # Authoritative source — the concept is directly from this standard
+    - type: authoritative
+      origin:
+        ref:
+          source: "ISO"
+          id: "10241-1"
+          version: "2011"
+        locality:
+          type: clause
+          reference_from: "3.1"
+    # Lineage source — historical/provenance reference
+    - type: lineage
+      origin:
+        ref:
+          source: "ISO/IEC Guide 2:2004"
+
+  related:
+    - type: supersedes
+      ref:
+        source: "ISO"
+        id: "10241-1"
+
+status: valid
+date_accepted: "2011-10-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v3/08-multilanguage-ara.yaml
+++ b/spec/fixtures/concept-model-examples/v3/08-multilanguage-ara.yaml
@@ -1,0 +1,27 @@
+# 08 — Arabic localization for 121-01-01
+#
+# Arabic uses Arab script. The entry_status field tracks this
+# localization's lifecycle independently.
+---
+id: 66666666-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: ara
+  script: Arab
+  terms:
+  - type: expression
+    designation: مجال كهرومغناطيسي
+    normative_status: preferred
+    language: ara
+    script: Arab
+  definition:
+  - content: مجال يتحدد بشدة المجال الكهربائي وشدة المجال المغناطيسي
+  entry_status: valid
+  sources:
+  - type: authoritative
+    status: identical
+    origin:
+      ref:
+        source: IEC
+        id: 60050-121
+        version: '1998'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/08-multilanguage-eng.yaml
+++ b/spec/fixtures/concept-model-examples/v3/08-multilanguage-eng.yaml
@@ -1,0 +1,25 @@
+# 08 — English localization for 121-01-01
+---
+id: 55555555-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  script: Latn
+  terms:
+  - type: expression
+    designation: electromagnetic field
+    normative_status: preferred
+  - type: abbreviation
+    designation: EMF
+    normative_status: admitted
+    acronym: true
+  definition:
+  - content: field determined by the electric field strength and the magnetic field
+      strength
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-121
+        version: '1998'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/08-multilanguage-jpn.yaml
+++ b/spec/fixtures/concept-model-examples/v3/08-multilanguage-jpn.yaml
@@ -1,0 +1,36 @@
+# 08 — Japanese localization for 121-01-01
+#
+# Japanese uses multiple scripts simultaneously. The script cascade
+# (ConceptData → Designation → Pronunciation) is demonstrated here.
+---
+id: 77777777-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: jpn
+  script: Hani
+  terms:
+  - type: expression
+    designation: 電磁界
+    normative_status: preferred
+  - type: expression
+    designation: デンジカイ
+    normative_status: admitted
+    script: Kana
+    pronunciation:
+    - content: denjikai
+      language: jpn
+      script: Latn
+      system: Var:jpn-Hrkt:Latn:Hepburn-1886
+  - type: expression
+    designation: denjikai
+    normative_status: admitted
+    script: Latn
+  definition:
+  - content: 界は電界の強さ及び磁界の強さによって定まる場
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-121
+        version: '1998'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/08-multilanguage-rus.yaml
+++ b/spec/fixtures/concept-model-examples/v3/08-multilanguage-rus.yaml
@@ -1,0 +1,34 @@
+# 08 — Russian localization for 121-01-01
+#
+# Russian uses Cyrl script. The conversion system (ISO 24229) can
+# specify the romanization system for transliteration.
+---
+id: 88888888-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: rus
+  script: Cyrl
+  terms:
+  - type: expression
+    designation: электромагнитное поле
+    normative_status: preferred
+    grammar_info:
+    - noun: true
+      number: singular
+      gender: "n"
+  - type: expression
+    designation: elektromagnitnoye pole
+    normative_status: admitted
+    script: Latn
+    term_type: transliterated_form
+    system: UN:rus-Cyrl:Latn:1993
+  definition:
+  - content: поле, определяемое напряженностью электрического поля и напряженностью
+      магнитного поля
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-121
+        version: '1998'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/08-multilanguage.yaml
+++ b/spec/fixtures/concept-model-examples/v3/08-multilanguage.yaml
@@ -1,0 +1,25 @@
+# 08 — Multi-Language & Multi-Script
+#
+# A managed concept with multiple localizations in different languages
+# and scripts. The localization map keys are ISO 639 three-character codes.
+#
+# Also demonstrates the per-designation language/script/system cascade:
+#   ConceptData defaults → Designation overrides → Pronunciation overrides
+---
+id: 121-01-01
+data:
+  identifier: 121-01-01
+  localized_concepts:
+    eng: 55555555-aaaa-bbbb-cccc-dddddddddddd
+    ara: 66666666-aaaa-bbbb-cccc-dddddddddddd
+    jpn: 77777777-aaaa-bbbb-cccc-dddddddddddd
+    rus: 88888888-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-121
+        version: '1998'
+status: valid
+date_accepted: '1998-08-01T00:00:00+00:00'

--- a/spec/fixtures/concept-model-examples/v3/09-nonverbal.yaml
+++ b/spec/fixtures/concept-model-examples/v3/09-nonverbal.yaml
@@ -1,0 +1,39 @@
+# 09 — Non-Verbal Representations
+#
+# Non-verbal representations (ISO 10241-1 §6.5) are URI references to
+# external resources: images, tables, or formulas. They are NOT embedded
+# content — they reference resources that live outside the concept model.
+---
+id: 99999999-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: Nyquist plot
+    normative_status: preferred
+  definition:
+  - content: a polar plot of the frequency response of a system, used in control theory
+      to assess stability
+  non_verbal_rep:
+  - type: image
+    ref: assets/nyquist-plot.svg
+    text: Nyquist plot for a typical second-order system
+    sources:
+    - type: authoritative
+      origin:
+        ref:
+          source: IEC 60050-351
+  - type: table
+    ref: urn:gcr:assets:stability-criteria-table
+    text: Comparison of stability criteria
+  - type: formula
+    ref: https://example.org/formulas/nyquist-criterion
+    text: Nyquist stability criterion formula
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-351
+        version: '2013'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/10-concept-reference-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/10-concept-reference-localized.yaml
@@ -1,0 +1,31 @@
+# 10 — Concept References (Localized)
+#
+# The references field on LocalizedConcept holds ConceptReference objects
+# for typed cross-references within concept data.
+---
+id: aaaaaaaa-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: insulating material
+    normative_status: preferred
+  definition:
+  - content: material used to prevent the flow of electric current
+  references:
+  - concept_id: 212-01-02
+    ref_type: local
+    term: insulation
+  - urn: urn:iso:std:iso:10241:term:3.1.1
+    ref_type: urn
+  - concept_id: 212-05-03
+    ref_type: designation
+    term: dielectric strength
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-212
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/10-concept-reference.yaml
+++ b/spec/fixtures/concept-model-examples/v3/10-concept-reference.yaml
@@ -1,0 +1,26 @@
+# 10 — Concept References
+#
+# ConceptReference is a typed reference to another concept — either local
+# (within the same glossary) or external (in another registry).
+# Used for domain assignments, concept mentions, and cross-references.
+---
+id: 212-01-01
+data:
+  identifier: 212-01-01
+  localized_concepts:
+    eng: aaaaaaaa-aaaa-bbbb-cccc-dddddddddddd
+  domains:
+  - concept_id: '212'
+    source: urn:iec:std:iec:60050
+    ref_type: domain
+  - concept_id: 212-01
+    source: urn:iec:std:iec:60050
+    ref_type: domain
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-212
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/11-lifecycle-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/11-lifecycle-localized.yaml
@@ -1,0 +1,46 @@
+# 11 — Lifecycle & Review (Localized)
+#
+# Localized concepts have their own entry_status, dates, and review metadata.
+# A localization can be retired while the managed concept remains valid.
+# Also demonstrates classification and review_type fields.
+---
+id: bbbbbbbb-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  entry_status: valid
+  terms:
+  - type: expression
+    designation: oscillation
+    normative_status: preferred
+    grammar_info:
+    - noun: true
+  definition:
+  - content: the variation, usually with time, of the magnitude of a quantity with
+      respect to a specified reference
+  dates:
+  - date: '1992-03-01T00:00:00+00:00'
+    type: accepted
+  - date: '2016-08-01T00:00:00+00:00'
+    type: amended
+  review_date: '2019-06-01T00:00:00+00:00'
+  review_decision_date: '2019-09-01T00:00:00+00:00'
+  review_decision_event: published
+  lineage_source_similarity: 95
+  release: '2.1'
+  sources:
+  - type: authoritative
+    status: identical
+    origin:
+      ref:
+        source: IEC
+        id: 60050-702
+        version: '1992'
+  - type: lineage
+    status: similar
+    origin:
+      ref:
+        source: IEC 60050-702:1988
+classification: admitted
+review_type: editorial
+status: valid
+date_accepted: '1992-03-01T00:00:00+00:00'

--- a/spec/fixtures/concept-model-examples/v3/11-lifecycle.yaml
+++ b/spec/fixtures/concept-model-examples/v3/11-lifecycle.yaml
@@ -1,0 +1,37 @@
+# 11 — Lifecycle & Review
+#
+# Managed concepts and localizations have lifecycle metadata:
+# status, dates, review information.
+
+---
+id: "702-01-01"
+data:
+  identifier: "702-01-01"
+  localized_concepts:
+    eng: bbbbbbbb-aaaa-bbbb-cccc-dddddddddddd
+
+  # Structured dates (alternative to simplified date_accepted at top level)
+  dates:
+    - date: "1992-03-01T00:00:00+00:00"
+      type: accepted
+    - date: "2016-08-01T00:00:00+00:00"
+      type: amended
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-702"
+        version: "1992"
+
+  # This concept supersedes an older entry
+  related:
+    - type: supersedes
+      ref:
+        source: "IEC"
+        id: "60050-702"
+        version: "1988"
+
+# Concept lifecycle status
+status: valid
+date_accepted: "1992-03-01T00:00:00+00:00"

--- a/spec/fixtures/concept-model-examples/v3/12-absent-designation-eng.yaml
+++ b/spec/fixtures/concept-model-examples/v3/12-absent-designation-eng.yaml
@@ -1,0 +1,23 @@
+# 12 — English: normal designation
+---
+id: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: kilogram
+    normative_status: preferred
+  - type: symbol
+    designation: kg
+    normative_status: admitted
+    international: true
+  definition:
+  - content: SI unit of mass
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-112
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/12-absent-designation-jpn.yaml
+++ b/spec/fixtures/concept-model-examples/v3/12-absent-designation-jpn.yaml
@@ -1,0 +1,41 @@
+# 12 — Japanese: absent designation for expression, international symbol shared
+#
+# Japanese may not have a native expression for some technical terms.
+# The `absent` flag makes this explicit. The international symbol (kg)
+# is still used — it has `international: true` and no language override,
+# so it applies across all localizations.
+---
+id: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: jpn
+  script: Hani
+  terms:
+  - type: expression
+    designation:
+    absent: true
+    language: eng
+    script: Latn
+  - type: symbol
+    designation: kg
+    normative_status: admitted
+    international: true
+  - type: expression
+    designation: キログラム
+    normative_status: admitted
+    script: Kana
+    term_type: transliterated_form
+    pronunciation:
+    - content: kiriguramu
+      language: jpn
+      script: Latn
+      system: Var:jpn-Hrkt:Latn:Hepburn-1886
+  definition:
+  - content: 質量のSI単位
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-112
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/12-absent-designation.yaml
+++ b/spec/fixtures/concept-model-examples/v3/12-absent-designation.yaml
@@ -1,0 +1,19 @@
+# 12 — Absent Designation & International Symbols
+#
+# The `absent` flag indicates no equivalent designation exists in this language.
+# The `international` flag indicates a symbol valid across all languages.
+---
+id: 112-02-01
+data:
+  identifier: 112-02-01
+  localized_concepts:
+    eng: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+    jpn: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: IEC
+        id: 60050-112
+        version: '2010'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated-localized.yaml
@@ -1,0 +1,39 @@
+# 13 — Superseded & Deprecated (Localized)
+#
+# The localized concept for a superseded entry. Shows deprecated
+# normative_status on designations and entry_status transitions.
+---
+id: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  entry_status: superseded
+  terms:
+  - type: expression
+    designation: quantity
+    normative_status: deprecated
+    grammar_info:
+    - noun: true
+      number: singular
+  - type: expression
+    designation: kind of quantity
+    normative_status: superseded
+    term_type: full_form
+  definition:
+  - content: property of a phenomenon, body, or substance, where the property has
+      a magnitude that can be expressed as a number and a reference
+    sources:
+    - type: authoritative
+      status: identical
+      origin:
+        ref:
+          source: IEC
+          id: 60050-112
+          version: '2010'
+  dates:
+  - date: '2010-01-01T00:00:00+00:00'
+    type: accepted
+  - date: '2023-06-01T00:00:00+00:00'
+    type: retired
+  release: '1.0'
+status: superseded
+date_accepted: '2010-01-01T00:00:00+00:00'

--- a/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated.yaml
+++ b/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated.yaml
@@ -1,0 +1,44 @@
+# 13 — Superseded & Deprecated Concept Lifecycle
+#
+# Demonstrates the deprecated/superseded lifecycle: a concept that was
+# replaced by a newer entry. Shows superseded_by at the managed level,
+# deprecated normative_status on designations, and retired dates.
+#
+# Companion: 13-superseded-deprecated-localized.yaml
+
+---
+id: "112-01-02"
+data:
+  identifier: "112-01-02"
+  localized_concepts:
+    eng: cccccccc-aaaa-bbbb-cccc-dddddddddddd
+
+  sources:
+    - type: authoritative
+      origin:
+        source: "IEC"
+        id: "60050-112"
+        version: "2010"
+
+# This concept is superseded — replaced by a newer entry
+related:
+  - type: superseded_by
+    content: "replaced by updated definition"
+    ref:
+      source: "IEC"
+      id: "112-01-03"
+
+  - type: deprecates
+    content: "deprecated older entry"
+    ref:
+      source: "IEC"
+      id: "112-01-01"
+
+# Concept lifecycle status: superseded
+status: superseded
+
+dates:
+  - date: "2010-01-01T00:00:00+00:00"
+    type: accepted
+  - date: "2023-06-01T00:00:00+00:00"
+    type: retired

--- a/spec/fixtures/concept-model-examples/v3/14-term-types.yaml
+++ b/spec/fixtures/concept-model-examples/v3/14-term-types.yaml
@@ -1,0 +1,183 @@
+# 14 — ISO 12620 Term Types (34 Values)
+#
+# ISO 12620 / TBX term_type classification for designations. The term_type
+# attribute categorizes a designation with respect to how it is formed or
+# where/how it is used.
+#
+# Categories:
+#   Orthographic/structural (10): abbreviation, acronym, clipped_term, full_form,
+#     initialism, short_form, transliterated_form, transcribed_form, truncation,
+#     variant
+#   Symbolic/formulaic (10): equation, formula, logical_expression,
+#     mathematical_expression, symbol, reference_symbol, figure_symbol,
+#     graphic_symbol, letter_symbol, roman_numeral
+#   Usage/provenance (14): code, common_name, entry_term, internationalism,
+#     international_scientific_term, part_number, phrase, phraseological_unit,
+#     scientific_name, shortcut, sku, standard_text, synonym, synonymous_phrase
+---
+id: dddddddd-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+  terms:
+  - type: expression
+    designation: World Health Organization
+    normative_status: preferred
+    term_type: full_form
+  - type: abbreviation
+    designation: WHO
+    normative_status: admitted
+    acronym: true
+    term_type: abbreviation
+  - type: abbreviation
+    designation: laser
+    normative_status: admitted
+    acronym: true
+    term_type: acronym
+  - type: abbreviation
+    designation: DNA
+    normative_status: admitted
+    initialism: true
+    term_type: initialism
+  - type: expression
+    designation: phone
+    normative_status: admitted
+    term_type: clipped_term
+  - type: expression
+    designation: app
+    normative_status: admitted
+    term_type: short_form
+  - type: expression
+    designation: catalog
+    normative_status: admitted
+    geographical_area: US
+    term_type: variant
+  - type: expression
+    designation: elektromagnitnoye pole
+    normative_status: admitted
+    language: rus
+    script: Latn
+    system: UN:rus-Cyrl:Latn:1993
+    term_type: transliterated_form
+  - type: expression
+    designation: Tōkyō
+    normative_status: admitted
+    language: jpn
+    script: Latn
+    system: Var:jpn-Hrkt:Latn:Hepburn-1886
+    term_type: transcribed_form
+  - type: expression
+    designation: app
+    normative_status: admitted
+    term_type: truncation
+  - type: symbol
+    designation: Ω
+    normative_status: preferred
+    international: true
+    term_type: symbol
+  - type: expression
+    designation: H₂O
+    normative_status: admitted
+    term_type: formula
+  - type: expression
+    designation: A ∧ B
+    normative_status: admitted
+    term_type: logical_expression
+  - type: expression
+    designation: E = mc²
+    normative_status: admitted
+    term_type: equation
+  - type: expression
+    designation: "∑(n=1 to ∞) 1/n²"
+    normative_status: admitted
+    term_type: mathematical_expression
+  - type: symbol
+    designation: "§"
+    normative_status: admitted
+    international: true
+    term_type: reference_symbol
+  - type: symbol
+    designation: "△"
+    normative_status: admitted
+    international: true
+    term_type: figure_symbol
+  - type: graphical_symbol
+    designation: "♔"
+    normative_status: admitted
+    international: true
+    term_type: graphic_symbol
+  - type: letter_symbol
+    designation: C
+    normative_status: admitted
+    international: true
+    term_type: letter_symbol
+  - type: expression
+    designation: XIV
+    normative_status: admitted
+    term_type: roman_numeral
+  - type: expression
+    designation: water
+    normative_status: admitted
+    term_type: common_name
+  - type: expression
+    designation: dihydrogen monoxide
+    normative_status: admitted
+    term_type: entry_term
+  - type: expression
+    designation: computer
+    normative_status: admitted
+    term_type: internationalism
+  - type: expression
+    designation: photosynthesis
+    normative_status: admitted
+    term_type: international_scientific_term
+  - type: expression
+    designation: liquid hydrogen oxide
+    normative_status: admitted
+    term_type: synonym
+  - type: expression
+    designation: oxidane
+    normative_status: admitted
+    term_type: synonymous_phrase
+  - type: expression
+    designation: 47kΩ resistor
+    normative_status: admitted
+    term_type: part_number
+  - type: expression
+    designation: standard atmospheric pressure
+    normative_status: admitted
+    term_type: phraseological_unit
+  - type: expression
+    designation: spec
+    normative_status: admitted
+    term_type: shortcut
+  - type: expression
+    designation: SKU-2024-BLK-M
+    normative_status: admitted
+    term_type: sku
+  - type: expression
+    designation: Not applicable
+    normative_status: admitted
+    term_type: standard_text
+  - type: expression
+    designation: ISO-8601
+    normative_status: admitted
+    term_type: code
+  - type: expression
+    designation: subject to change without notice
+    normative_status: admitted
+    term_type: phrase
+  - type: expression
+    designation: Homo sapiens
+    normative_status: admitted
+    term_type: scientific_name
+  definition:
+  - content: comprehensive example demonstrating all ISO 12620 term type classifications
+      across orthographic, symbolic, and usage categories
+  sources:
+  - type: authoritative
+    origin:
+      ref:
+        source: ISO
+        id: '12620'
+        version: '2019'
+status: valid

--- a/spec/fixtures/concept-model-examples/v3/15-citation-features.yaml
+++ b/spec/fixtures/concept-model-examples/v3/15-citation-features.yaml
@@ -1,0 +1,135 @@
+# 15 — Citation & Locality Features
+#
+# Demonstrates all V3 citation and locality features:
+# - Structured citation ref (source + id + version)
+# - Locality with single reference (clause, section, page)
+# - Locality with range (reference_from → reference_to)
+# - Custom locality (name-value pairs)
+# - Link field (URL to source document)
+# - Original field
+#
+# V3 format: origin.ref is always a hash { source, id, version? }.
+# Never a plain string — use V2 backward compat for string refs.
+
+---
+id: eeeeeeee-aaaa-bbbb-cccc-dddddddddddd
+data:
+  language_code: eng
+
+  terms:
+    - type: expression
+      designation: "quality management"
+      normative_status: preferred
+
+  definition:
+    - content: >-
+        coordinated activities to direct and control an organization with
+        regard to quality
+      sources:
+        # Structured citation with clause locality (single point)
+        - type: authoritative
+          status: identical
+          origin:
+            ref:
+              source: "ISO"
+              id: "9000"
+              version: "2015"
+            locality:
+              type: clause
+              reference_from: "3.3.3"
+
+    - content: >-
+        the aspect of overall management that determines and implements
+        quality policy
+      sources:
+        # Locality range: clause 3.3.3 through 3.3.5
+        - type: authoritative
+          status: modified
+          origin:
+            ref:
+              source: "ISO"
+              id: "8402"
+              version: "1994"
+            locality:
+              type: clause
+              reference_from: "3.3.3"
+              reference_to: "3.3.5"
+          modification: "updated from 1994 terminology"
+
+  notes:
+    - content: >-
+        Quality management includes quality planning, quality control,
+        quality assurance, and quality improvement.
+      sources:
+        # Citation with link field
+        - type: authoritative
+          status: identical
+          origin:
+            ref:
+              source: "ISO"
+              id: "9000"
+              version: "2015"
+            link: "https://www.iso.org/standard/45481.html"
+            locality:
+              type: section
+              reference_from: "2.2"
+
+    - content: >-
+        Quality management frameworks may use custom schema versioning.
+      sources:
+        # Citation with custom_locality
+        - type: lineage
+          status: context_added
+          origin:
+            ref:
+              source: "Internal quality manual QM-2024"
+            custom_locality:
+              - name: schema
+                value: QMS_Framework_v3
+              - name: version
+                value: "3"
+              - name: department
+                value: engineering
+
+    - content: >-
+        This definition was adapted from an earlier standard.
+      sources:
+        # Citation with original field (transitional)
+        - type: lineage
+          status: restyle
+          origin:
+            ref:
+              source: "ISO/TC 176 document N45"
+            original: "ISO 8402:1986, quality management"
+
+    - content: >-
+        Page-range reference using locality.
+      sources:
+        # Locality range: pages 42-47
+        - type: authoritative
+          status: similar
+          origin:
+            ref:
+              source: "ISO"
+              id: "9000"
+              version: "2005"
+            locality:
+              type: page
+              reference_from: "42"
+              reference_to: "47"
+
+  sources:
+    # Multiple locality types on the concept source
+    - type: authoritative
+      status: identical
+      origin:
+        ref:
+          source: "ISO"
+          id: "9001"
+          version: "2015"
+        link: "https://www.iso.org/standard/62085.html"
+        locality:
+          type: annex
+          reference_from: "A"
+
+status: valid

--- a/spec/unit/rdf/ontology_conformance_spec.rb
+++ b/spec/unit/rdf/ontology_conformance_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rdf/turtle"
+require "glossarist/transforms/concept_to_gloss_transform"
+
+RSpec.describe "RDF output conformance to glossarist ontology" do
+  let(:gloss_ns) { Glossarist::Rdf::Namespaces::GlossaristNamespace.uri }
+  let(:skos_ns) { "http://www.w3.org/2004/02/skos/core#" }
+  let(:xl_ns) { "http://www.w3.org/2008/05/skos-xl#" }
+  let(:dct_ns) { "http://purl.org/dc/terms/" }
+
+  def parse_graph(turtle)
+    g = RDF::Graph.new
+    RDF::Turtle::Reader.new(turtle) { |r| r.each_statement { |s| g << s } }
+    g
+  end
+
+  def concept_graph
+    collection = Glossarist::ManagedConceptCollection.new
+    collection.load_from_files(fixtures_path("concept_collection_v2"))
+    concept = collection.first
+    transform = Glossarist::Transforms::ConceptToGlossTransform.new(concept)
+    parse_graph(transform.to_turtle)
+  end
+
+  describe "Concept node" do
+    let(:graph) { concept_graph }
+    let(:concept_node) { graph.query([nil, RDF.type, RDF::URI("#{gloss_ns}Concept")]).first.subject }
+
+    it "has gloss:Concept type" do
+      expect(graph.query([concept_node, RDF.type, RDF::URI("#{gloss_ns}Concept")])).not_to be_empty
+    end
+
+    it "has skos:Concept type" do
+      expect(graph.query([concept_node, RDF.type, RDF::URI("#{skos_ns}Concept")])).not_to be_empty
+    end
+
+    it "has gloss:identifier" do
+      id_stmts = graph.query([concept_node, RDF::URI("#{gloss_ns}identifier"), nil])
+      expect(id_stmts).not_to be_empty
+      expect(id_stmts.first.object).to be_a(RDF::Literal)
+    end
+
+    it "has gloss:hasLocalization targeting gloss:LocalizedConcept" do
+      l10n_stmts = graph.query([concept_node, RDF::URI("#{gloss_ns}hasLocalization"), nil])
+      l10n_stmts.each do |stmt|
+        expect(graph.query([stmt.object, RDF.type, RDF::URI("#{gloss_ns}LocalizedConcept")])).not_to be_empty
+      end
+    end
+  end
+
+  describe "LocalizedConcept node" do
+    let(:graph) { concept_graph }
+    let(:l10n_node) { graph.query([nil, RDF.type, RDF::URI("#{gloss_ns}LocalizedConcept")]).first.subject }
+
+    it "has dcterms:language" do
+      lang_stmts = graph.query([l10n_node, RDF::URI("#{dct_ns}language"), nil])
+      expect(lang_stmts).not_to be_empty
+    end
+
+    it "is connected to Concept via gloss:hasLocalization" do
+      concept_node = graph.query([nil, RDF.type, RDF::URI("#{gloss_ns}Concept")]).first.subject
+      l10n_stmts = graph.query([concept_node, RDF::URI("#{gloss_ns}hasLocalization"), l10n_node])
+      expect(l10n_stmts).not_to be_empty
+    end
+  end
+
+  describe "Designation node" do
+    let(:graph) { concept_graph }
+    let(:desig_nodes) { graph.query([nil, RDF::URI("#{xl_ns}literalForm"), nil]).map(&:subject) }
+
+    it "every designation has a literalForm" do
+      expect(desig_nodes).not_to be_empty
+    end
+
+    it "every designation is typed as a glossarist designation class" do
+      desig_nodes.each do |node|
+        types = graph.query([node, RDF.type, nil]).map { |s| s.object.to_s }
+        designation_types = types.select { |t| t.start_with?(gloss_ns) && !t.include?("Concept") }
+        expect(designation_types).not_to be_empty, "Node #{node} has no glossarist designation type. Types: #{types}"
+      end
+    end
+  end
+
+  describe "source node" do
+    let(:graph) { concept_graph }
+    let(:source_nodes) { graph.query([nil, RDF.type, RDF::URI("#{gloss_ns}ConceptSource")]).map(&:subject) }
+
+    it "has gloss:ConceptSource type" do
+      expect(source_nodes).not_to be_empty
+    end
+
+    it "has gloss:sourceType" do
+      source_nodes.each do |node|
+        type_stmts = graph.query([node, RDF::URI("#{gloss_ns}sourceType"), nil])
+        expect(type_stmts).not_to be_empty, "ConceptSource #{node} missing gloss:sourceType"
+      end
+    end
+  end
+
+  describe "v3 example round-trip" do
+    v3_dir = File.expand_path("../../fixtures/concept-model-examples/v3", __dir__)
+
+    Dir.glob(File.join(v3_dir, "*.yaml")).sort.each do |path|
+      basename = File.basename(path, ".yaml")
+      data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time])
+      next unless data.is_a?(Hash) && data.dig("data", "language_code")
+
+      it "#{basename}: designations produce gloss:Designation subclass types" do
+        lc = Glossarist::LocalizedConcept.of_yaml(data)
+        mc = Glossarist::ManagedConcept.new(data: { id: basename })
+        mc.add_l10n(lc)
+
+        graph = parse_graph(Glossarist::Transforms::ConceptToGlossTransform.new(mc).to_turtle)
+        desig_types = graph.query([nil, RDF.type, nil])
+          .map { |s| s.object.to_s }
+          .select { |t| t.start_with?(gloss_ns) && !t.end_with?("Concept") }
+        expect(desig_types).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/unit/rdf/round_trip_spec.rb
+++ b/spec/unit/rdf/round_trip_spec.rb
@@ -5,7 +5,8 @@ require "rdf/turtle"
 require "glossarist/transforms/concept_to_gloss_transform"
 
 module RoundTripConstants
-  EXAMPLES_DIR = File.expand_path("../../../../concept-model/schemas/v2/examples", __dir__)
+  V2_EXAMPLES_DIR = File.expand_path("../../fixtures/concept-model-examples/v2", __dir__)
+  V3_EXAMPLES_DIR = File.expand_path("../../fixtures/concept-model-examples/v3", __dir__)
   GLOSS = Glossarist::Rdf::Namespaces::GlossaristNamespace.uri
   SKOS = Glossarist::Rdf::Namespaces::SkosNamespace.uri
   XL = Glossarist::Rdf::Namespaces::SkosxlNamespace.uri
@@ -25,11 +26,20 @@ RSpec.describe "Round-trip: YAML → Ruby → Turtle → verify triples" do
     RoundTripConstants::GLOSS
   end
 
-  # ── Localized concept examples ────────────────────────────────────────
+  def minimal_l10n
+    l = Glossarist::LocalizedConcept.new
+    l.data.language_code = "eng"
+    l.data.terms = [Glossarist::Designation::Expression.new(designation: "placeholder", type: "expression", normative_status: "preferred")]
+    l
+  end
 
-  describe "localized concept examples" do
-    RoundTripConstants::EXAMPLES_DIR.then do |dir|
-      Dir.glob(File.join(dir, "*.yaml")).sort.each do |path|
+  # Shared examples for both v2 and v3 example directories.
+  # Tests that every example YAML parses and produces valid RDF.
+  shared_examples "concept model examples" do |version_label, examples_dir|
+    skip "#{version_label} examples not available at #{examples_dir}" unless Dir.exist?(examples_dir)
+
+    describe "#{version_label} localized concept examples" do
+      Dir.glob(File.join(examples_dir, "*.yaml")).sort.each do |path|
         basename = File.basename(path, ".yaml")
         data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time])
         next unless data.is_a?(Hash) && data.dig("data", "language_code")
@@ -48,20 +58,9 @@ RSpec.describe "Round-trip: YAML → Ruby → Turtle → verify triples" do
         end
       end
     end
-  end
 
-  # ── Managed concept examples ──────────────────────────────────────────
-
-  describe "managed concept examples" do
-    let(:minimal_l10n) do
-      l = Glossarist::LocalizedConcept.new
-      l.data.language_code = "eng"
-      l.data.terms = [Glossarist::Designation::Expression.new(designation: "placeholder", type: "expression", normative_status: "preferred")]
-      l
-    end
-
-    RoundTripConstants::EXAMPLES_DIR.then do |dir|
-      Dir.glob(File.join(dir, "*.yaml")).sort.each do |path|
+    describe "#{version_label} managed concept examples" do
+      Dir.glob(File.join(examples_dir, "*.yaml")).sort.each do |path|
         basename = File.basename(path, ".yaml")
         data = YAML.safe_load(File.read(path), permitted_classes: [Date, Time])
         next unless data.is_a?(Hash) && (data.dig("data", "localized_concepts") || data.dig("data", "identifier"))
@@ -83,6 +82,9 @@ RSpec.describe "Round-trip: YAML → Ruby → Turtle → verify triples" do
       end
     end
   end
+
+  include_examples "concept model examples", "V2", RoundTripConstants::V2_EXAMPLES_DIR
+  include_examples "concept model examples", "V3", RoundTripConstants::V3_EXAMPLES_DIR
 
   # ── Specific fixture-based round-trip verification ────────────────────
 


### PR DESCRIPTION
## Summary

Aligns glossarist-ruby with the concept-model v3 ontology spec:

### Config sync
- Add `exact_match` to `related_concept.type` (SKOS exactMatch)
- Add 9 missing `iso12620.term_type` values: code, figure_symbol, graphic_symbol, letter_symbol, mathematical_expression, phrase, reference_symbol, roman_numeral, scientific_name, truncation

### RDF testing
- **Round-trip spec**: Extended to cover both v2 AND v3 concept model examples using shared_examples pattern, with local fixtures (no external repo dependency)
- **Ontology conformance spec**: New spec validating RDF transform output against gloss ontology structure (Concept type/identifier/localization, LocalizedConcept language, Designation subclass typing, ConceptSource structure)
- **Local fixtures**: 31 v2 + 31 v3 example YAMLs copied into spec/fixtures/ for CI independence

### Test results
- 1138 examples, 0 failures (full suite)
- 100 examples, 0 failures (new + modified specs)
- RuboCop clean on all changed Ruby files
