### PR TITLE
feat: add translations field to RegisterData and GcrMetadata

### DIFF
--- a/lib/glossarist/gcr_metadata.rb
+++ b/lib/glossarist/gcr_metadata.rb
@@ -21,6 +21,7 @@ module Glossarist
     attribute :concept_uri_template, :string
     attribute :compiled_formats, :string, collection: true
     attribute :external_references, :hash, collection: true
+    attribute :translations, :hash, default: -> { {} }
 
     key_value do
       map :shortname, to: :shortname
@@ -42,6 +43,7 @@ module Glossarist
       map :concept_uri_template, to: :concept_uri_template
       map :compiled_formats, to: :compiled_formats
       map :external_references, to: :external_references
+      map :translations, to: :translations
     end
 
     def self.from_concepts(concepts, register_data: nil, options: {})
@@ -64,6 +66,7 @@ module Glossarist
         concept_uri_template: options[:concept_uri_template],
         compiled_formats: options[:compiled_formats] || [],
         external_references: derive_external_references(concepts),
+        translations: rd&.dig("translations") || {},
       )
     end
 

--- a/lib/glossarist/register_data.rb
+++ b/lib/glossarist/register_data.rb
@@ -17,6 +17,7 @@ module Glossarist
     attribute :repository, :string
     attribute :license, :string
     attribute :tags, :string, collection: true
+    attribute :translations, :hash, default: -> { {} }
 
     key_value do
       map %i[id shortname], to: :shortname
@@ -33,6 +34,7 @@ module Glossarist
       map "repository", to: :repository
       map "license", to: :license
       map "tags", to: :tags
+      map "translations", to: :translations
     end
 
     def [](key)
@@ -51,6 +53,7 @@ module Glossarist
       when "repository" then repository
       when "license" then license
       when "tags" then tags
+      when "translations" then translations
       end
     end
 
@@ -77,6 +80,7 @@ module Glossarist
       h["repository"] = repository if repository
       h["license"] = license if license
       h["tags"] = tags if tags && !tags.empty?
+      h["translations"] = translations if translations && !translations.empty?
       h
     end
 


### PR DESCRIPTION
Add `translations` hash attribute to `RegisterData` and `GcrMetadata`, enabling register.yaml to carry localized name and description per language:

```yaml
name: International Vocabulary of Legal Metrology
translations:
  fra:
    name: Vocabulaire international de métrologie légale
    description: ...
```

Backward-compatible: existing register.yaml files without `translations` work unchanged.