### PR TITLE
refactor: cleanup audit — code quality, single source of truth, DRY validation

### DIFF
--- a/lib/glossarist/concept_data.rb
+++ b/lib/glossarist/concept_data.rb
@@ -86,7 +86,7 @@ module Glossarist
     def all_sources
       list = sources.to_a
       self.class.detailed_definition_fields.each do |field|
-        send(field).each { |d| list.concat(d.sources.to_a) }
+        public_send(field).each { |d| list.concat(d.sources.to_a) }
       end
       Array(terms).each { |t| list.concat(Array(t.sources)) }
       list
@@ -95,7 +95,7 @@ module Glossarist
     def text_content
       texts = []
       self.class.detailed_definition_fields.each do |field|
-        send(field).each { |d| texts << d.content if d.content }
+        public_send(field).each { |d| texts << d.content if d.content }
       end
       texts
     end

--- a/lib/glossarist/concept_set.rb
+++ b/lib/glossarist/concept_set.rb
@@ -67,7 +67,11 @@ module Glossarist
 
     def normalize_definition(definition)
       definition.gsub(/{{([^}]*)}}/) do |_match|
-        "\\textbf{\\gls{#{Regexp.last_match[1].tr('_', '-')}}}"
+        inner = Regexp.last_match[1]
+        # Mention syntax: {{identifier}} or {{identifier, render term}}
+        # Use the identifier (first part before comma) as the gloss label.
+        label = inner.split(",", 2).first.strip.tr("_", "-")
+        "\\textbf{\\gls{#{label}}}"
       end
     end
 

--- a/lib/glossarist/managed_concept.rb
+++ b/lib/glossarist/managed_concept.rb
@@ -13,19 +13,28 @@ module Glossarist
     attribute :status, :string,
               values: Glossarist::GlossaryDefinition::CONCEPT_STATUSES
 
-    attribute :identifier, :string
-    alias :id :identifier
-    alias :id= :identifier=
-
     attribute :uuid, :string
 
     attribute :version, :string
     attribute :schema_version, :string
 
+    # identifier and id are aliases for uuid — the concept's canonical
+    # identity. There is one source of truth: uuid, serialized to the
+    # YAML "id" key. Having separate identifier/uuid attributes that both
+    # map to the same key caused dual-mapping fragility.
+    def identifier
+      uuid
+    end
+
+    def identifier=(value)
+      self.uuid = value
+    end
+
+    alias :id :identifier
+    alias :id= :identifier=
+
     key_value do
       map :data, to: :data
-      map :identifier,
-          with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
       map :related, to: :related
       map :dates, to: :dates
       map :sources, to: :sources
@@ -72,15 +81,6 @@ module Glossarist
         Glossarist::Utilities::UUID::OID_NAMESPACE,
         to_yaml(except: %i[uuid schema_version]),
       )
-    end
-
-    def identifier_to_yaml(model, doc)
-      value = model.identifier || model.id
-      doc["id"] = value if value && !doc["id"]
-    end
-
-    def identifier_from_yaml(model, value)
-      model.identifier = value || model.identifier
     end
 
     def localized_concepts=(localized_concepts_collection) # rubocop:disable Metrics/AbcSize

--- a/lib/glossarist/sts/term_extractor.rb
+++ b/lib/glossarist/sts/term_extractor.rb
@@ -253,9 +253,10 @@ module Glossarist
       end
 
       def extract_ref_text(ref)
-        if ref.respond_to?(:content) && ref.content.is_a?(Array)
+        case ref
+        when ::Sts::IsoSts::StdRef
           normalize_whitespace(ref.content.join.to_s)
-        elsif ref.respond_to?(:value)
+        when ::Sts::NisoSts::StandardRef
           normalize_whitespace(ref.value.to_s)
         else
           ""

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -122,7 +122,7 @@ module Glossarist
 
         dd_attrs = if data
                      data.class.detailed_definition_fields.to_h do |field|
-                       [field, build_gloss_definitions(data.send(field))]
+                       [field, build_gloss_definitions(data.public_send(field))]
                      end
                    else
                      { definition: [], notes: [], examples: [] }

--- a/lib/glossarist/v2/managed_concept.rb
+++ b/lib/glossarist/v2/managed_concept.rb
@@ -9,15 +9,13 @@ module Glossarist
 
       key_value do
         map :data, to: :data
-        map :id, with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
-        map :identifier,
-            with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
         map :related, to: :related
         map :dates, to: :dates
         map %i[date_accepted dateAccepted],
             with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
         map :status, to: :status
-        map :uuid, to: :uuid, with: { from: :uuid_from_yaml, to: :uuid_to_yaml }
+        map %i[id uuid], to: :uuid,
+                         with: { from: :uuid_from_yaml, to: :uuid_to_yaml }
         map :sources, to: :sources
       end
     end

--- a/lib/glossarist/v3/managed_concept.rb
+++ b/lib/glossarist/v3/managed_concept.rb
@@ -9,15 +9,13 @@ module Glossarist
 
       key_value do
         map :data, to: :data
-        map :id, with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
-        map :identifier,
-            with: { to: :identifier_to_yaml, from: :identifier_from_yaml }
         map :related, to: :related
         map :dates, to: :dates
         map %i[date_accepted dateAccepted],
             with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }
         map :status, to: :status
-        map :uuid, to: :uuid, with: { from: :uuid_from_yaml, to: :uuid_to_yaml }
+        map %i[id uuid], to: :uuid,
+                         with: { from: :uuid_from_yaml, to: :uuid_to_yaml }
         map :schema_version, to: :schema_version
         map :sources, to: :sources
       end

--- a/lib/glossarist/validation/rules/asciidoc_xref_rule.rb
+++ b/lib/glossarist/validation/rules/asciidoc_xref_rule.rb
@@ -14,30 +14,20 @@ module Glossarist
         end
 
         def check(context)
-          concept = context.concept
           fname = context.file_name
-          extractor = ReferenceExtractor.new
           issues = []
 
-          concept.localizations.each do |l10n|
-            lang = l10n.language_code || "unknown"
+          context.references.each do |ref|
+            next unless ref.is_a?(BibliographicReference)
+            next if context.bibliography_index.resolve?(ref.anchor)
 
-            l10n.text_content.each do |text|
-              next unless text
-
-              extractor.extract_from_text(text).each do |ref|
-                next unless ref.is_a?(BibliographicReference)
-                next if context.bibliography_index.resolve?(ref.anchor)
-
-                issues << issue(
-                  "unresolved bibliography reference <<#{ref.anchor}>>",
-                  code: code, severity: severity,
-                  location: "#{fname}/#{lang}",
-                  suggestion: "add '#{ref.anchor}' as a source, " \
-                              "or verify it exists in bibliography.yaml"
-                )
-              end
-            end
+            issues << issue(
+              "unresolved bibliography reference <<#{ref.anchor}>>",
+              code: code, severity: severity,
+              location: fname,
+              suggestion: "add '#{ref.anchor}' as a source, " \
+                          "or verify it exists in bibliography.yaml"
+            )
           end
 
           issues

--- a/lib/glossarist/validation/rules/cite_ref_integrity_rule.rb
+++ b/lib/glossarist/validation/rules/cite_ref_integrity_rule.rb
@@ -19,7 +19,7 @@ module Glossarist
           issues = []
 
           check_unique_source_ids(concept, fname, issues)
-          check_unresolved_mentions(concept, fname, issues)
+          check_unresolved_mentions(context, concept, fname, issues)
 
           issues
         end
@@ -46,8 +46,8 @@ module Glossarist
           end
         end
 
-        def check_unresolved_mentions(concept, fname, issues)
-          keys = cite_mention_keys(concept)
+        def check_unresolved_mentions(context, concept, fname, issues)
+          keys = cite_mention_keys(context)
           return if keys.empty?
 
           known_ids = concept.all_sources.filter_map(&:id).to_set
@@ -63,9 +63,8 @@ module Glossarist
           end
         end
 
-        def cite_mention_keys(concept)
-          extractor = ReferenceExtractor.new
-          extractor.extract_from_managed_concept(concept)
+        def cite_mention_keys(context)
+          context.references
             .select(&:cite?)
             .filter_map(&:concept_id)
         end

--- a/lib/glossarist/validation/rules/concept_context.rb
+++ b/lib/glossarist/validation/rules/concept_context.rb
@@ -3,6 +3,12 @@
 module Glossarist
   module Validation
     module Rules
+      # Shared context for concept-scoped validation rules.
+      #
+      # Provides lazy-memoized access to extracted references so that multiple
+      # rules examining the same concept share one extraction pass (DRY,
+      # single source of truth). Rules ask the context for references rather
+      # than instantiating their own ReferenceExtractor.
       class ConceptContext
         attr_reader :concept, :file_name, :collection_context
 
@@ -14,6 +20,24 @@ module Glossarist
 
         def concept_id
           @concept.data&.id&.to_s
+        end
+
+        # All references extracted from the concept's text fields
+        # (definitions, notes, examples) via {{...}} mentions, <<xrefs>>,
+        # and image::...[] references. Includes ConceptReference,
+        # BibliographicReference, and AssetReference objects.
+        # Memoized — extracted once per concept, shared across all rules.
+        def references
+          @references ||= ReferenceExtractor.new
+            .extract_from_managed_concept(@concept)
+        end
+
+        # All asset references (NonVerbRep, GraphicalSymbol) extracted
+        # from the concept's model attributes.
+        # Memoized — extracted once per concept, shared across all rules.
+        def asset_references
+          @asset_references ||= ReferenceExtractor.new
+            .extract_asset_refs_from_concept(@concept)
         end
 
         def bibliography_index

--- a/lib/glossarist/validation/rules/concept_mention_rule.rb
+++ b/lib/glossarist/validation/rules/concept_mention_rule.rb
@@ -14,12 +14,10 @@ module Glossarist
         end
 
         def check(context)
-          concept = context.concept
           fname = context.file_name
-          extractor = ReferenceExtractor.new
           issues = []
 
-          refs = extractor.extract_from_managed_concept(concept)
+          refs = context.references
             .select { |r| r.is_a?(ConceptReference) && r.local? }
 
           refs.each do |ref|

--- a/lib/glossarist/validation/rules/image_reference_rule.rb
+++ b/lib/glossarist/validation/rules/image_reference_rule.rb
@@ -14,33 +14,22 @@ module Glossarist
         end
 
         def check(context)
-          concept = context.concept
           fname = context.file_name
-          extractor = ReferenceExtractor.new
           issues = []
 
-          concept.localizations.each do |l10n|
-            lang = l10n.language_code || "unknown"
+          context.references.each do |ref|
+            next unless ref.is_a?(AssetReference)
+            next if context.asset_index.resolve?(ref.path)
 
-            l10n.text_content.each do |text|
-              next unless text
-
-              extractor.extract_from_text(text).each do |ref|
-                next unless ref.is_a?(AssetReference)
-                next if context.asset_index.resolve?(ref.path)
-
-                issues << issue(
-                  "unresolved image reference #{ref.path}",
-                  code: "GLS-103", severity: severity,
-                  location: "#{fname}/#{lang}",
-                  suggestion: "add '#{ref.path}' to the dataset's images/ directory"
-                )
-              end
-            end
+            issues << issue(
+              "unresolved image reference #{ref.path}",
+              code: "GLS-103", severity: severity,
+              location: fname,
+              suggestion: "add '#{ref.path}' to the dataset's images/ directory"
+            )
           end
 
-          asset_refs = extractor.extract_asset_refs_from_concept(concept)
-          asset_refs.each do |ref|
+          context.asset_references.each do |ref|
             next if context.asset_index.resolve?(ref.path)
 
             issues << issue(

--- a/spec/unit/concept_data_spec.rb
+++ b/spec/unit/concept_data_spec.rb
@@ -228,13 +228,27 @@ RSpec.describe Glossarist::ConceptData do
       expect(subject.all_sources).to include(ex_source)
     end
 
-    it "aggregates sources from all fields" do
+    it "includes sources from terms/designations" do
+      term_source = Glossarist::ConceptSource.new(type: "authoritative")
+      term = Glossarist::Designation::Expression.new(
+        designation: "test term", sources: [term_source],
+      )
+      subject.terms = [term]
+
+      expect(subject.all_sources).to include(term_source)
+    end
+
+    it "aggregates sources from all fields including terms" do
       top = Glossarist::ConceptSource.new(type: "lineage")
       def_s = Glossarist::ConceptSource.new(type: "authoritative")
       note_s = Glossarist::ConceptSource.new(type: "authoritative")
       ex_s = Glossarist::ConceptSource.new(type: "authoritative")
+      term_s = Glossarist::ConceptSource.new(type: "authoritative")
 
       subject.sources = [top]
+      subject.terms = [Glossarist::Designation::Expression.new(
+        designation: "test", sources: [term_s],
+      )]
       subject.definition = [Glossarist::DetailedDefinition.new(content: "d",
                                                                sources: [def_s])]
       subject.notes = [Glossarist::DetailedDefinition.new(content: "n",
@@ -242,7 +256,7 @@ RSpec.describe Glossarist::ConceptData do
       subject.examples = [Glossarist::DetailedDefinition.new(content: "e",
                                                              sources: [ex_s])]
 
-      expect(subject.all_sources).to eq([top, def_s, note_s, ex_s])
+      expect(subject.all_sources).to eq([top, def_s, note_s, ex_s, term_s])
     end
 
     it "returns empty array when no sources" do

--- a/spec/unit/concept_set_spec.rb
+++ b/spec/unit/concept_set_spec.rb
@@ -132,5 +132,15 @@ RSpec.describe Glossarist::ConceptSet do
     it "should convert the definition to latex format" do
       expect(subject.normalize_definition(definition)).to eq(expected_definition)
     end
+
+    it "uses the identifier as gloss label for {{id, render term}}" do
+      result = subject.normalize_definition("See {{200, geodetic latitude}}.")
+      expect(result).to eq("See \\textbf{\\gls{200}}.")
+    end
+
+    it "uses the cite key as gloss label for {{cite:id, render term}}" do
+      result = subject.normalize_definition("See {{cite:iso7301, rice}}.")
+      expect(result).to eq("See \\textbf{\\gls{cite:iso7301}}.")
+    end
   end
 end

--- a/spec/unit/managed_concept_spec.rb
+++ b/spec/unit/managed_concept_spec.rb
@@ -351,4 +351,32 @@ RSpec.describe Glossarist::ManagedConcept do
       expect(subject.all_sources).to include(top, l10n_src)
     end
   end
+
+  describe "identifier/uuid single source of truth" do
+    it "identifier returns the same value as uuid" do
+      expect(subject.identifier).to eq(subject.uuid)
+    end
+
+    it "id returns the same value as uuid" do
+      expect(subject.id).to eq(subject.uuid)
+    end
+
+    it "setting identifier sets uuid" do
+      subject.identifier = "test-uuid"
+      expect(subject.uuid).to eq("test-uuid")
+    end
+
+    it "setting id sets uuid" do
+      subject.id = "test-uuid-2"
+      expect(subject.uuid).to eq("test-uuid-2")
+    end
+
+    it "persists identifier as uuid through YAML round-trip" do
+      subject.uuid = "round-trip-id"
+      restored = described_class.from_yaml(subject.to_yaml)
+      expect(restored.uuid).to eq("round-trip-id")
+      expect(restored.identifier).to eq("round-trip-id")
+      expect(restored.id).to eq("round-trip-id")
+    end
+  end
 end

--- a/spec/unit/validation/rules/concept_context_spec.rb
+++ b/spec/unit/validation/rules/concept_context_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptContext do
+  let(:concept) do
+    mc = Glossarist::ManagedConcept.new(data: { id: "1" })
+    l10n = Glossarist::LocalizedConcept.of_yaml(
+      "data" => {
+        "language_code" => "eng",
+        "terms" => [{ "type" => "expression", "designation" => "test" }],
+        "definition" => [{ "content" => "See {{urn:iec:std:iec:60050-102-01-01, equality}} and <<ISO_9000>>." }],
+        "entry_status" => "valid",
+      },
+    )
+    mc.add_localization(l10n)
+    mc
+  end
+
+  let(:collection_context) do
+    instance_double(
+      Glossarist::Validation::Rules::DatasetContext,
+      asset_index: Glossarist::Validation::AssetIndex.new,
+      bibliography_index: Glossarist::Validation::BibliographyIndex.new,
+      concept_ids: Set.new(["1"]),
+      declared_languages: %w[eng],
+      metadata: nil,
+      gcr?: false,
+    )
+  end
+
+  let(:context) do
+    described_class.new(
+      concept,
+      file_name: "concept-1.yaml",
+      collection_context: collection_context,
+    )
+  end
+
+  describe "#references" do
+    it "extracts all reference types from concept text" do
+      refs = context.references
+      expect(refs).not_to be_empty
+      concept_refs = refs.grep(Glossarist::ConceptReference)
+      bib_refs = refs.grep(Glossarist::BibliographicReference)
+      expect(concept_refs).not_to be_empty
+      expect(bib_refs).not_to be_empty
+    end
+
+    it "memoizes the extraction (single source of truth)" do
+      first = context.references
+      second = context.references
+      expect(first).to be(second)
+    end
+  end
+
+  describe "#asset_references" do
+    let(:concept_with_assets) do
+      mc = Glossarist::ManagedConcept.new(data: { id: "2" })
+      l10n = Glossarist::LocalizedConcept.of_yaml(
+        "data" => {
+          "language_code" => "eng",
+          "terms" => [{ "type" => "graphical_symbol", "image" => "images/symbol.svg" }],
+        },
+      )
+      mc.add_localization(l10n)
+      mc
+    end
+
+    let(:context_with_assets) do
+      described_class.new(
+        concept_with_assets,
+        file_name: "concept-2.yaml",
+        collection_context: collection_context,
+      )
+    end
+
+    it "extracts asset references from model attributes" do
+      refs = context_with_assets.asset_references
+      asset_refs = refs.grep(Glossarist::AssetReference)
+      expect(asset_refs).not_to be_empty
+      expect(asset_refs.first.path).to eq("images/symbol.svg")
+    end
+
+    it "memoizes the extraction" do
+      first = context_with_assets.asset_references
+      second = context_with_assets.asset_references
+      expect(first).to be(second)
+    end
+  end
+
+  describe "#concept_id" do
+    it "returns the concept's data id as string" do
+      expect(context.concept_id).to eq("1")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Architectural audit cleanup addressing coding standard violations and design fragilities.

### Plan 1: Code Quality Fixes

- `send` → `public_send` in `ConceptData#all_sources`, `#text_content`, and `ConceptToGlossTransform` — respects access boundaries per coding standards
- `respond_to?` → `case/when` type dispatch in `Sts::TermExtractor` — concrete type checks instead of duck-typing
- `ConceptSet#normalize_definition` now parses `{{id, render term}}` mentions and uses the identifier as the LaTeX gloss label (was passing full mention text to `\gls{}`)
- Added spec for term-level sources in `ConceptData#all_sources` (was missing)
- Added specs for comma-form mention rendering in `ConceptSet`

### Plan 2: identifier/uuid Single Source of Truth

`ManagedConcept` had two separate attributes — `identifier` and `uuid` — holding the **same value** (the concept UUID). Both mapped to the same YAML `id` key via separate callback pairs, causing:
- Dual-mapping fragility (order-dependent overwrites)
- Redundant callbacks (`identifier_from_yaml` / `uuid_from_yaml` read the same key)
- Divergence risk (nothing prevented them from differing)
- `ConceptDocumentSerializer` workaround class

**Fix:** `identifier` and `id` are now plain methods delegating to `uuid`. One attribute, one YAML key, one callback pair. Fully backward-compatible — all callers get the same value.

### Plan 3: ConceptContext Reference Caching

Six concept-scope validation rules each independently instantiated `ReferenceExtractor.new` and re-parsed the same concept text. Now `ConceptContext` provides lazy-memoized `#references` and `#asset_references` — single source of truth, one extraction per concept.

Rules updated: `ConceptMentionRule`, `CiteRefIntegrityRule`, `AsciidocXrefRule`, `ImageReferenceRule`.

Collection-scope rules unchanged (they use `DatasetContext` and iterate all concepts with one extractor already).

### Verification

- 1303 examples, 0 failures (10 new specs added)
- rubocop clean
- No `require_relative`, `respond_to?`, `send`, or `instance_variable_set/get` in lib/