### PR TITLE
feat: section cascading membership — transitive ancestor traversal

### DIFF
--- a/lib/glossarist/dataset_register.rb
+++ b/lib/glossarist/dataset_register.rb
@@ -56,6 +56,37 @@ module Glossarist
       nil
     end
 
+    # Returns all ancestor section IDs for a given section, from immediate
+    # parent up to the root. Implements the cascading membership semantics:
+    # a concept in section "3.1.1" is also a member of "3.1" and "3".
+    # (concept-model: gloss:hasChildSection / gloss:hasParentSection are
+    # owl:TransitiveProperty.)
+    def section_ancestor_ids(target_id)
+      @section_parent_index ||= build_section_parent_index
+      @section_parent_index[target_id] || []
+    end
+
+    # Returns all section IDs that a concept belongs to, including
+    # transitive ancestor sections (cascading membership).
+    #
+    # Resolution order (concept-model convention):
+    # 1. Explicit domains[] entries with ref_type: "section"
+    # 2. Term-ID-prefix derivation fallback (longest registered prefix)
+    #
+    # @param concept [ManagedConcept, #data] the concept to resolve
+    # @return [Array<String>] section IDs, child-first then ancestors
+    def concept_section_ids(concept)
+      explicit = explicit_section_ids(concept)
+      ids = explicit.empty? ? derive_section_ids_from_id(concept) : explicit
+      ids.flat_map { |id| [id] + section_ancestor_ids(id) }.uniq
+    end
+
+    # Returns true if the given section ID exists anywhere in the section
+    # tree (root or descendant).
+    def section_exists?(target_id)
+      !section_by_id(target_id).nil?
+    end
+
     def self.from_file(path)
       return nil unless File.exist?(path)
 
@@ -67,6 +98,54 @@ module Glossarist
       return nil unless File.exist?(register_path)
 
       from_file(register_path)
+    end
+
+    private
+
+    # Build a flat child→[ancestor_ids] index by walking the section tree.
+    # Ancestors are ordered immediate-parent-first (closest section first).
+    # @example for sections [{id:"3", children:[{id:"3.1"}]}]:
+    #   { "3.1" => ["3"] }
+    def build_section_parent_index
+      index = {}
+      walk_section_tree(sections, []) do |section, ancestors|
+        index[section.id] = ancestors.reverse unless ancestors.empty?
+      end
+      index
+    end
+
+    def walk_section_tree(nodes, ancestors, &block)
+      Array(nodes).each do |section|
+        yield section, ancestors
+        child_ancestors = ancestors + [section.id]
+        walk_section_tree(section.children, child_ancestors, &block)
+      end
+    end
+
+    def explicit_section_ids(concept)
+      domains = concept.respond_to?(:data) ? concept.data&.domains : nil
+      Array(domains).select { |d| d.ref_type == "section" }
+        .filter_map(&:concept_id)
+    end
+
+    # Term-ID-prefix derivation: when a concept has no explicit section
+    # domains, derive section membership from its identifier using the
+    # longest registered section prefix.
+    # @example "103-01-01" with section "103" registered → ["103"]
+    def derive_section_ids_from_id(concept)
+      concept_id = concept.respond_to?(:data) ? concept.data&.id : nil
+      return [] unless concept_id
+
+      all_section_ids = collect_all_section_ids
+      all_section_ids.select { |sid| concept_id.start_with?("#{sid}-", "#{sid}.") }
+        .max_by(&:length)
+        &.then { |sid| [sid] } || []
+    end
+
+    def collect_all_section_ids
+      ids = []
+      walk_section_tree(sections, []) { |section, _| ids << section.id }
+      ids
     end
   end
 end

--- a/lib/glossarist/validation/rules/dataset_context.rb
+++ b/lib/glossarist/validation/rules/dataset_context.rb
@@ -31,6 +31,13 @@ module Glossarist
           nil
         end
 
+        # Loads the dataset's register.yaml as a DatasetRegister (with
+        # hierarchical sections, urn, ordering). Returns nil if no
+        # register.yaml exists or it uses the legacy format.
+        def dataset_register
+          @dataset_register ||= load_dataset_register
+        end
+
         def bibliography_index
           @bibliography_index ||= BibliographyIndex.build_from_concepts(
             concepts, dataset_path: @path
@@ -97,6 +104,13 @@ module Glossarist
             end
           end
           index
+        end
+
+        def load_dataset_register
+          reg_path = File.join(@path, "register.yaml")
+          return nil unless File.exist?(reg_path)
+
+          DatasetRegister.from_file(reg_path)
         end
       end
     end

--- a/lib/glossarist/validation/rules/domain_ref_rule.rb
+++ b/lib/glossarist/validation/rules/domain_ref_rule.rb
@@ -27,6 +27,21 @@ module Glossarist
                 suggestion: "Provide at least concept_id or urn for the domain reference",
               )
             end
+
+            next unless domain.ref_type == "section" && domain.concept_id
+
+            register = context.collection_context.dataset_register
+            next unless register
+
+            unless register.section_exists?(domain.concept_id)
+              issues << issue(
+                "domain #{idx + 1} references section '#{domain.concept_id}' " \
+                "that does not exist in register.yaml",
+                location: fname,
+                suggestion: "Add section '#{domain.concept_id}' to " \
+                            "register.yaml or fix the reference",
+              )
+            end
           end
 
           issues

--- a/spec/unit/dataset_register_spec.rb
+++ b/spec/unit/dataset_register_spec.rb
@@ -137,6 +137,68 @@ RSpec.describe Glossarist::DatasetRegister do
     end
   end
 
+  describe "section cascading membership" do
+    let(:hierarchical_yaml) do
+      <<~YAML
+        ---
+        schema_type: glossarist
+        schema_version: '3'
+        id: hierarchical
+        urn: "urn:test:hierarchical"
+        sections:
+          - id: "1"
+            names: { eng: "General" }
+          - id: "3"
+            names: { eng: "Geometric" }
+            children:
+              - id: "3.1"
+                names: { eng: "Points" }
+                children:
+                  - id: "3.1.1"
+                    names: { eng: "Pixels" }
+      YAML
+    end
+
+    let(:reg) { described_class.from_yaml(hierarchical_yaml) }
+
+    it "returns ancestor chain for deeply nested section" do
+      expect(reg.section_ancestor_ids("3.1.1")).to eq(%w[3.1 3])
+    end
+
+    it "returns immediate parent for child of top-level" do
+      expect(reg.section_ancestor_ids("3.1")).to eq(["3"])
+    end
+
+    it "returns empty for top-level section" do
+      expect(reg.section_ancestor_ids("1")).to eq([])
+    end
+
+    it "returns empty for non-existent section" do
+      expect(reg.section_ancestor_ids("999")).to eq([])
+    end
+
+    it "resolves concept section IDs with cascading ancestors" do
+      concept = Glossarist::ManagedConcept.new(
+        data: {
+          id: "3.1.1",
+          domains: [{ concept_id: "3.1.1", ref_type: "section" }],
+        },
+      )
+      expect(reg.concept_section_ids(concept)).to eq(%w[3.1.1 3.1 3])
+    end
+
+    it "derives section from term-ID-prefix when no explicit domains" do
+      concept = Glossarist::ManagedConcept.new(data: { id: "3-01-01" })
+      # No explicit domain → derive from "3" prefix
+      expect(reg.concept_section_ids(concept)).to eq(["3"])
+    end
+
+    it "returns empty when concept has no domains and no matching prefix" do
+      concept = Glossarist::ManagedConcept.new(data: { id: "999" })
+      expect(reg.concept_section_ids(concept)).to eq([])
+    end
+  end
+
   describe "from_file" do
     it "loads from an actual register.yaml file" do
       path = File.expand_path("../../fixtures/viml-2022-register.yaml", __dir__)


### PR DESCRIPTION
## Summary

Implements the cascading membership semantics from the concept-model ([aac762e](https://github.com/glossarist/concept-model/commit/aac762e)): `gloss:hasChildSection` / `gloss:hasParentSection` are now `owl:TransitiveProperty`. A concept in section `3.1.1` is also a member of `3.1` and `3`.

### Changes

**DatasetRegister — section resolution API:**

| Method | Description |
|---|---|
| `#section_ancestor_ids(id)` | Immediate-parent-first ancestor chain (transitive closure upward) |
| `#concept_section_ids(concept)` | All section IDs a concept belongs to: explicit `domains[]` + transitive ancestors. Falls back to term-ID-prefix derivation when no explicit domains. |
| `#section_exists?(id)` | Checks section tree membership (root or descendant) |

Term-ID-prefix derivation convention (concept-model documented):
- `103-01-01` → section `103` (longest registered prefix wins)
- `3.1.1` → section `3`

**Validation:**
- `DomainRefRule` now validates that `ref_type: "section"` domain references resolve against sections in `register.yaml`
- `DatasetContext#dataset_register` loads `register.yaml` as `DatasetRegister` (with hierarchical sections)

### Verified against concept-model example 18

```
concept ex-3.1.1 in section 3.1
→ concept_section_ids(concept) = ["3.1", "3"]
```

### How concept-browser uses this

The concept-browser builds a `sectionParentMap` (child→parent) from `register.yaml` and adds parent group IDs to concept groups for hierarchical filtering. glossarist-ruby now provides the canonical resolution API that the browser can consume.

### Verification

- 1339 examples, 0 failures
- rubocop clean