### PR TITLE
fix: remove duplicate extension_attributes declaration in Concept

### DIFF
--- a/lib/glossarist/concept.rb
+++ b/lib/glossarist/concept.rb
@@ -5,7 +5,6 @@ module Glossarist
     attribute :uuid, :string
     attribute :subject, :string
     attribute :non_verb_rep, NonVerbRep, collection: true
-    attribute :extension_attributes, :string
     attribute :lineage_source, :string
     attribute :localizations, :hash
     attribute :extension_attributes, :hash
@@ -16,8 +15,6 @@ module Glossarist
       map :termid, to: :termid
       map :subject, to: :subject
       map %i[non_verb_rep nonVerbRep], to: :non_verb_rep
-      map %i[extension_attributes extensionAttributes],
-          to: :extension_attributes
       map %i[lineage_source lineageSource], to: :lineage_source
       map :localizations, to: :localizations
       map %i[extension_attributes extensionAttributes],


### PR DESCRIPTION
## Summary

`Concept` declared `extension_attributes` **twice** with conflicting types:
```ruby
attribute :extension_attributes, :string   # line 8 — original
attribute :extension_attributes, :hash     # line 11 — overwrites silently
```

And mapped it twice in `key_value` (lines 19-20 and 23-24).

`extension_attributes` is a configurable hash for user-registered extra attributes (via `glossarist.yaml` or CLI `--extra-attributes`). The `:string` declaration was the original; `:hash` was added when the feature evolved but the old one was never removed.

### Fix
Remove the duplicate `:string` declaration and duplicate `key_value` mapping. Keep `:hash` (the correct type).

### Origin
Found via review of PR #143 (closed). PR #143 identified this bug but bundled it in a large misaligned PR.

### Verification
- 1339 examples, 0 failures
- `Concept.new(extension_attributes: { "custom_field" => "value" })` returns `Hash` type correctly