### PR TITLE
Bump glossarist to 2.8.14

### DIFF
--- a/lib/glossarist/version.rb
+++ b/lib/glossarist/version.rb
@@ -4,5 +4,5 @@
 #
 
 module Glossarist
-  VERSION = "2.8.13"
+  VERSION = "2.8.14"
 end


### PR DESCRIPTION
Version bump to release the extension_attributes duplicate fix (#181). Previous release workflow (2.8.13) was triggered after a force-push reverted the version.rb to 2.8.12, so 2.8.13 already exists on RubyGems but this fix was not included.