### PR TITLE
Bump glossarist to 2.8.15

### DIFF
--- a/lib/glossarist/version.rb
+++ b/lib/glossarist/version.rb
@@ -4,5 +4,5 @@
 #
 
 module Glossarist
-  VERSION = "2.8.14"
+  VERSION = "2.8.15"
 end


### PR DESCRIPTION
Version bump to release non-verbal entities (Figure, Table, Formula) from #184. v2.8.14 tag already exists from an earlier state, so 2.8.15 ensures the figure models are published.