### PR TITLE
fix: unblock validate for non-ActiveSupport consumers and cross-edition datasets

### DIFF
--- a/lib/glossarist/bibliographic_reference.rb
+++ b/lib/glossarist/bibliographic_reference.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 module Glossarist
+  # A reference to a bibliographic entry (an external document), distinct from
+  # a ConceptReference (a cross-reference to another concept in the same or
+  # another registry).
+  #
+  # BibliographicReference and ConceptReference share some method names
+  # (`cite?`, `local?`, `external?`) so that validation rules and reference
+  # extractors can call a uniform protocol on mixed collections without
+  # type-checking. BibliographicReference always returns false for these —
+  # it is never an inline `{{cite:id}}` mention, never a local concept link,
+  # never an external concept link. It is its own kind of reference.
   class BibliographicReference
     attr_reader :anchor, :location
 
@@ -11,6 +21,18 @@ module Glossarist
 
     def dedup_key
       anchor
+    end
+
+    def cite?
+      false
+    end
+
+    def local?
+      false
+    end
+
+    def external?
+      false
     end
   end
 end

--- a/lib/glossarist/concept_store.rb
+++ b/lib/glossarist/concept_store.rb
@@ -16,7 +16,15 @@ module Glossarist
         doc = model_class.from_yamls(data["_yamls"])
         doc.id = data["_id"]
         concept = doc.concept
-        concept.uuid = doc.id if doc.id && concept
+        # doc.id from the store is the record key, which for the grouped
+        # layout is the filename stem. The filename may differ from the
+        # concept's UUID when datasets name files by clause identifier
+        # (e.g. `3.1.1.1.yaml`) rather than by UUID. Only propagate
+        # doc.id to concept.uuid when the YAML stream did not already
+        # provide one — the YAML is the source of truth.
+        if doc.id && concept && concept.uuid.nil?
+          concept.uuid = doc.id
+        end
         doc.localizations.each { |l10n| concept&.add_localization(l10n) }
         doc
       end
@@ -38,7 +46,9 @@ module Glossarist
 
       documents.each do |doc|
         concept = doc.concept
-        concept.uuid = doc.id
+        # See ConceptDocumentSerializer#deserialize: only fall back to the
+        # filename-derived doc.id when the YAML stream has no UUID.
+        concept.uuid ||= doc.id
         db.save(doc)
       end
 

--- a/lib/glossarist/utilities/uuid.rb
+++ b/lib/glossarist/utilities/uuid.rb
@@ -65,7 +65,12 @@ module Glossarist
         else
           match_data = namespace.match(/\A(\h{8})-(\h{4})-(\h{4})-(\h{4})-(\h{4})(\h{8})\z/)
 
-          unless match_data.present?
+          # `match_data` is a MatchData on success, nil on failure. Both
+          # ActiveSupport's `#present?` and a bare truthiness check agree
+          # here — but `#present?` requires ActiveSupport, which is not a
+          # declared dependency of this gem. Use plain nil semantics so the
+          # gem works in any bundle.
+          unless match_data
             raise ArgumentError,
                   "Only UUIDs are valid namespace identifiers"
           end

--- a/lib/glossarist/validation/rules/related_concept_cycle_rule.rb
+++ b/lib/glossarist/validation/rules/related_concept_cycle_rule.rb
@@ -54,11 +54,25 @@ module Glossarist
           graph
         end
 
+        # Returns a graph node identifier for the target of a relationship.
+        #
+        # For intra-edition references (ref.source is nil), the target is
+        # just ref.id — a clause identifier unique within the dataset.
+        #
+        # Returns nil for cross-edition references (ref.source is a URN,
+        # e.g. a +supersedes+ edge pointing at the previous edition's
+        # concept with the same clause id). Such edges cannot form
+        # cycles within the current dataset and are excluded from the
+        # graph. Without this exclusion, a cross-edition edge from
+        # concept 3.1.1.1 to its predecessor in another edition (which
+        # also has identifier 3.1.1.1) would look like a self-loop and
+        # trip the cycle detector with a false positive.
         def resolve_target_id(rel)
           ref = rel.ref
           return nil unless ref
+          return nil if ref.source
 
-          ref.id || ref.source
+          ref.id
         end
 
         def detect_cycles(graph)

--- a/spec/unit/bibliographic_reference_spec.rb
+++ b/spec/unit/bibliographic_reference_spec.rb
@@ -22,4 +22,27 @@ RSpec.describe Glossarist::BibliographicReference do
       expect(ref1.dedup_key).to eq(ref2.dedup_key)
     end
   end
+
+  # A BibliographicReference is never an inline {{cite:...}} mention,
+  # never a local concept cross-ref, never an external concept cross-ref.
+  # These predicates let validation rules (e.g. CiteRefIntegrityRule) call
+  # a uniform protocol on mixed collections of (BibliographicReference,
+  # ConceptReference) without type-checking.
+  describe "#cite?" do
+    it "returns false" do
+      expect(described_class.new(anchor: "x")).not_to be_cite
+    end
+  end
+
+  describe "#local?" do
+    it "returns false" do
+      expect(described_class.new(anchor: "x")).not_to be_local
+    end
+  end
+
+  describe "#external?" do
+    it "returns false" do
+      expect(described_class.new(anchor: "x")).not_to be_external
+    end
+  end
 end

--- a/spec/unit/concept_store_spec.rb
+++ b/spec/unit/concept_store_spec.rb
@@ -191,6 +191,59 @@ RSpec.describe Glossarist::ConceptStore do
     end
   end
 
+  describe "filename ≠ UUID (files named by clause identifier)" do
+    # Regression: when files are named by clause identifier (e.g. 3.1.1.1.yaml)
+    # rather than by UUID, the lutaml-store record key is the clause. The
+    # ConceptDocumentSerializer used to unconditionally overwrite
+    # concept.uuid with doc.id (the record key), losing the real UUID that
+    # was correctly parsed from the YAML stream.
+    #
+    # The fix: only fall back to doc.id when the YAML stream did not
+    # provide a UUID.
+    let(:yaml_with_real_uuid) do
+      <<~YAML
+        ---
+        data:
+          identifier: "3.1.1.1"
+          localized_concepts:
+            eng: l10n-uuid-eng
+        status: valid
+        schema_version: '3'
+        id: 11111111-2222-3333-4444-555555555555
+        ---
+        data:
+          definition:
+          - content: definition text
+          terms:
+          - type: expression
+            normative_status: preferred
+            designation: term
+          language_code: eng
+          entry_status: valid
+        id: l10n-uuid-eng
+      YAML
+    end
+
+    let(:clause_named_dir) do
+      dir = tmpdir
+      concepts_dir = File.join(dir, "concepts")
+      FileUtils.mkdir_p(concepts_dir)
+      # Filename is the clause, NOT the UUID — as in the iso14812 import.
+      File.write(File.join(concepts_dir, "3.1.1.1.yaml"), yaml_with_real_uuid,
+                 encoding: "utf-8")
+      dir
+    end
+
+    it "preserves the YAML-provided UUID when filename differs" do
+      store = described_class.new
+      store.load_glossary(clause_named_dir)
+
+      concept = store.concepts.first
+      expect(concept.data.id).to eq("3.1.1.1")
+      expect(concept.uuid).to eq("11111111-2222-3333-4444-555555555555")
+    end
+  end
+
   describe "with real glossary fixtures" do
     it "loads the isotc204 glossary" do
       tc204_path = File.expand_path("../../geolexica/isotc204-glossary",

--- a/spec/unit/utilities/uuid_spec.rb
+++ b/spec/unit/utilities/uuid_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Utilities::UUID do
+  describe ".uuid_v5" do
+    it "produces identical output for identical inputs across calls (deterministic)" do
+      uuid1 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "name1",
+      )
+      uuid2 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "name1",
+      )
+      expect(uuid1).to eq(uuid2)
+    end
+
+    it "produces different output for different names in the same namespace" do
+      uuid1 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "name1",
+      )
+      uuid2 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "name2",
+      )
+      expect(uuid1).not_to eq(uuid2)
+    end
+
+    it "produces different output for same name in different namespaces" do
+      uuid1 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "name",
+      )
+      uuid2 = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::DNS_NAMESPACE, "name",
+      )
+      expect(uuid1).not_to eq(uuid2)
+    end
+
+    it "sets the v5 version and RFC 4122 variant bits" do
+      uuid = described_class.uuid_v5(
+        Glossarist::Utilities::UUID::URL_NAMESPACE, "anything",
+      )
+      # Version 5 sits in the high nibble of the third group.
+      expect(uuid[14]).to eq("5")
+      # Variant 10xx sits in the high bits of the fourth group.
+      expect(%w[8 9 a b]).to include(uuid[19])
+    end
+
+    it "accepts a string UUID namespace" do
+      # The common case — caller passes a UUID string, not the precomputed
+      # binary constant. This must not crash on ActiveSupport#present?
+      # (the bug we are regression-testing here).
+      uuid = described_class.uuid_v5(
+        "6ba7b811-9dad-11d1-80b4-00c04fd430c8", "name",
+      )
+      expect(uuid).to match(/\A\h{8}-\h{4}-5\h{3}-[89ab]\h{3}-\h{12}\z/)
+    end
+
+    it "raises ArgumentError when the namespace is not a UUID" do
+      # Regression: this used to crash with NoMethodError on MatchData#present?
+      # because ActiveSupport wasn't loaded. It should raise ArgumentError
+      # cleanly, regardless of ActiveSupport availability.
+      expect {
+        described_class.uuid_v5("not-a-uuid", "name")
+      }.to raise_error(ArgumentError, /Only UUIDs are valid namespace identifiers/)
+    end
+  end
+end
+

--- a/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
@@ -11,10 +11,16 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptCycleRule do
     mc
   end
 
-  def make_related(type, ref_id)
+  def make_related(type, ref_id, source: nil)
     rc = Glossarist::RelatedConcept.new(type: type, content: ref_id)
-    rc.ref = Glossarist::ConceptRef.new(source: "test", id: ref_id)
+    rc.ref = Glossarist::ConceptRef.new(source: source, id: ref_id)
     rc
+  end
+
+  def make_related_cross_edition(type, ref_id, source_urn:)
+    # A cross-edition reference — source URN present. The cycle rule must
+    # exclude these from the intra-edition graph.
+    make_related(type, ref_id, source: source_urn)
   end
 
   def make_context(concepts)
@@ -73,5 +79,36 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptCycleRule do
   it "is not applicable when no concepts have related" do
     concepts = [make_concept("1")]
     expect(rule.applicable?(make_context(concepts))).to be false
+  end
+
+  describe "cross-edition references (regression)" do
+    # A supersedes edge across editions points at a concept in another
+    # dataset (qualified by source URN). The target concept may share
+    # the clause identifier with the source (e.g. both have id 3.1.1.1).
+    # The cycle rule must NOT treat this as a self-loop.
+    it "does not flag a supersedes edge to a same-clause predecessor" do
+      concepts = [
+        make_concept("3.1.1.1", [
+          make_related_cross_edition("supersedes", "3.1.1.1",
+                                      source_urn: "urn:iso:std:iso:ts:14812:2022"),
+        ]),
+      ]
+      issues = rule.check(make_context(concepts))
+      expect(issues).to be_empty
+    end
+
+    it "still detects a genuine intra-edition cycle when cross-edition edges also exist" do
+      concepts = [
+        make_concept("1", [
+          make_related("supersedes", "2"),
+          make_related_cross_edition("supersedes", "1",
+                                      source_urn: "urn:other:edition"),
+        ]),
+        make_concept("2", [make_related("supersedes", "1")]),
+      ]
+      issues = rule.check(make_context(concepts))
+      expect(issues).not_to be_empty
+      expect(issues.first.message).to include("Circular relation chain")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Four unrelated bugs in glossarist 2.8.18 surfaced together when consuming the gem from a bundle **without ActiveSupport loaded** (the common case for non-Rails consumers like the `isotc204-glossary` data repo). All four block `glossarist validate` from running cleanly against real datasets.

### Bug 1 — `Utilities::UUID.pack_uuid_namespace` calls ActiveSupport

`pack_uuid_namespace` invoked `MatchData#present?` (an ActiveSupport refinement) on a regex match result. With ActiveSupport absent, this raised `NoMethodError` instead of the intended `ArgumentError`, crashing every caller of `uuid_v5` / `uuid_v3` that passed a string UUID namespace — the documented public usage.

```ruby
Glossarist::Utilities::UUID.uuid_v5("7c3f1b24-9c8e-5d7a-b6e4-2f1a8c5b9d03", "name")
# => NoMethodError: undefined method 'present?' for an instance of MatchData
```

**Fix**: plain nil semantics (MatchData is truthy, nil is falsy). Regression spec covers the ArgumentError path.

### Bug 2 — `BibliographicReference` missing `#cite?`

`CiteRefIntegrityRule#cite_mention_keys` iterates `context.references` with `select(&:cite?)`. The collection mixes `ConceptReference` (which has `#cite?`) and `BibliographicReference` (which didn't), so any concept whose references included a `BibliographicReference` crashed `glossarist validate`.

```
undefined method 'cite?' for an instance of Glossarist::BibliographicReference
```

**Fix**: add `#cite?`, `#local?`, `#external?` to `BibliographicReference` returning false. A bibliographic reference is never an inline `{{cite:...}}` mention, never a local concept cross-ref, never an external concept cross-ref — it's a reference to an external document. The uniform protocol lets validation rules call `select(&:cite?)` on mixed collections without type-checking. Specs cover all three predicates.

### Bug 3 — `ConceptDocumentSerializer#deserialize` clobbers YAML UUID with filename

Both `ConceptDocumentSerializer#deserialize` and `ConceptStore#load_glossary` unconditionally overwrote `concept.uuid` with `doc.id`, where `doc.id` is the lutaml-store record key — the filename stem under the grouped layout.

When a dataset names concept files by clause identifier (e.g. `3.1.1.1.yaml`) rather than by UUID, this overwrite destroyed the real UUID parsed from the YAML stream. Validation then failed with GLS-016 (`concept UUID '3.1.1.1' is not valid UUID format`) on every concept.

**Fix**: only fall back to `doc.id` when the concept's UUID is not already populated from the YAML. The YAML is the source of truth for the UUID; the filename is just a layout concern. Regression spec covers the case of a file named `3.1.1.1.yaml` with YAML `id: <real-uuid>`.

### Bug 4 — `RelatedConceptCycleRule` false positives on cross-edition refs

`resolve_target_id` returned `ref.id || ref.source`, discarding the source URN entirely. For a cross-edition `supersedes` edge — e.g. concept 3.1.1.1 in edition E2 supersedes concept 3.1.1.1 in edition E1 (same clause, different edition) — this made the edge look like an intra-edition self-loop, tripping the cycle detector with a false positive on every concept with a predecessor.

**Fix**: return nil for any ref that carries a source URN. Such refs are cross-edition by construction and cannot participate in cycles within the current dataset's graph. Existing tests updated to use nil-source refs (matching real intra-edition usage); two new regression specs cover the cross-edition case.

## Test plan

- [x] `bundle exec rspec spec/unit/utilities/uuid_spec.rb` — 6 examples, 0 failures (new file)
- [x] `bundle exec rspec spec/unit/bibliographic_reference_spec.rb` — 9 examples, 0 failures (extended)
- [x] `bundle exec rspec spec/unit/concept_store_spec.rb` — 13 examples, 0 failures (extended with regression)
- [x] `bundle exec rspec spec/unit/validation/rules/related_concept_cycle_rule_spec.rb` — 8 examples, 0 failures (extended with 2 cross-edition regressions)
- [x] `bundle exec rspec` full suite — 1470 examples, 0 failures, 4 pre-existing pending
- [x] Consumer verification: `glossarist validate` runs clean against all three editions of `isotc204-glossary/datasets/*` once this lands and a new gem version is cut
