### PR TITLE
chore(config): remove normative_status artifacts, add grammar number values

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -29,9 +29,6 @@ designation:
       - admitted
       - deprecated
       - superseded
-      - <símbolo> # in iev-data => '<symbol>'
-      - 티에스 # in iev-data => translates to 'TS' I think it is a synonym and not status.
-      - prąd startowy # in iev-data => 'starting current' I think it is a synonym and not status.
   relationship_type:
     # Term-level (designation-to-designation within the same concept entry)
     - abbreviated_form_for
@@ -169,6 +166,8 @@ grammar_info:
     - singular
     - dual
     - plural
+    - mass
+    - other_number
 
 concept:
   status:


### PR DESCRIPTION
Cleanup from TODO.harmonize/01 + TODO.v3 audit.

## What

Removed 3 `designation.base.normative_status` values that were data artifacts from iev-data leakage, not real statuses:
- `<símbolo>` (Spanish for `<symbol>`)
- `티에스` (Korean, apparently `TS`)
- `prąd startowy` (Polish for `starting current`)

Added 2 missing `grammar_info.number` values from TBX-Linguist:
- `mass` (mass noun)
- `other_number` (catch-all for number systems outside singular/dual/plural)

## Why

Flagged by TODO.harmonize and TODO.v3 audits. The artifacts cause downstream consumers (concept-browser, glossarist-js) to render garbage in language switchers. The number gap causes valid TBX imports to fail validation.

## Verification

- Full suite: 1455 examples, 0 failures, 4 pending
- `bundle exec ruby -e "require 'glossarist'; puts Glossarist::GlossaryDefinition::DESIGNATION_BASE_NORMATIVE_STATUSES"` → `['preferred', 'admitted', 'deprecated', 'superseded']`
- Rubocop clean on changed file

## Related

Resolves the artifact-removal portion of TODO.harmonize/01 and TODO.v3/03. Other items in those TODOs (register enum, domain-as-collection, RDF ontology validation) require coordinated model class changes and remain open.