### PR TITLE
fix(ci): pass GLOSSARIST_CI_PAT_TOKEN through to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,3 +23,4 @@ jobs:
       next_version: ${{ github.event.inputs.next_version }}
     secrets:
       rubygems-api-key: ${{ secrets.GLOSSARIST_CI_RUBYGEMS_API_KEY }}
+      pat_token: ${{ secrets.GLOSSARIST_CI_PAT_TOKEN }}


### PR DESCRIPTION
## Summary
- `release.yml` was passing only `rubygems-api-key` to the upstream `metanorma/ci` reusable workflow, omitting `pat_token`. The post-publish verification step then dispatched `release-passed` with the limited `GITHUB_TOKEN`, which cannot trigger workflow runs, so the step timed out at 90s and reported failure — even though the gem was already published.
- `rake.yml` already passes this secret; this PR aligns `release.yml` with the same pattern.

## Test plan
- [x] Diff matches the existing pattern in `rake.yml`
- [ ] Next release workflow run's final step ("Verify release-passed dispatch acknowledged downstream") passes instead of timing out
