### PR TITLE
chore(concept-model): sync vendor to v3.1.0 tag, document prefixes.ttl

### DIFF
--- a/data/concept-model/README.md
+++ b/data/concept-model/README.md
@@ -12,6 +12,7 @@ concept-model.
 
 | File | Purpose |
 |------|---------|
+| `prefixes.ttl` | Canonical prefix bindings SSOT — consumed verbatim by every Turtle/JSON-LD serializer in the ecosystem |
 | `glossarist.context.jsonld` | JSON-LD term map — reference |
 | `glossarist.ttl` | OWL ontology (reference; not currently read at runtime) |
 | `shapes/glossarist.shacl.ttl` | SHACL shapes — loaded by `Glossarist::Validation::ShaclValidator` at runtime |
@@ -21,8 +22,9 @@ concept-model.
 Update these files from the latest concept-model tag:
 
 ```bash
-rake glossarist:sync:model          # fetches latest from glossarist/concept-model
-rake glossarist:sync:model[v3.0.0]  # pin to a specific tag
+rake glossarist:sync:model          # fetches latest released tag
+rake glossarist:sync:model[v3.1.0]  # pin to a specific tag
+rake glossarist:sync:model[main]    # tracking upstream main (uncommon)
 ```
 
 The sync task fetches via the GitHub raw endpoint (no clone needed).

--- a/data/concept-model/SOURCE.json
+++ b/data/concept-model/SOURCE.json
@@ -1,5 +1,5 @@
 {
   "repo": "glossarist/concept-model",
-  "ref": "8d5972e",
-  "syncedAt": "2026-07-05T02:25:47Z"
+  "ref": "v3.1.0",
+  "syncedAt": "2026-07-05T05:08:16Z"
 }

--- a/lib/glossarist/tasks/sync_model.rb
+++ b/lib/glossarist/tasks/sync_model.rb
@@ -3,6 +3,7 @@
 require "json"
 require "fileutils"
 require "net/http"
+require "time"
 require "uri"
 
 module Glossarist


### PR DESCRIPTION
## Summary

Tracks concept-model's first tagged release past v3.0.0. v3.1.0 was cut at `49e4dc4` in response to glossarist/concept-model#66 (the tag lifecycle proposal). This PR aligns glossarist-ruby's vendor pin and tidies up the sync mechanism docs.

### Changes (2 commits)

1. **`chore(concept-model): flip vendor pin from SHA to v3.1.0 tag`** — Updates `data/concept-model/SOURCE.json` `ref` from `8d5972e` to `v3.1.0`. The four vendored data files (`prefixes.ttl`, `glossarist.ttl`, `glossarist.context.jsonld`, `shapes/glossarist.shacl.ttl`) are byte-identical to the SHA pin — v3.1.0 only added release-process docs upstream.

2. **`chore(sync): document prefixes.ttl, add explicit require "time"`** — Small follow-ups:
   - `data/concept-model/README.md`: documents `prefixes.ttl` (added as sync target in #194 but missing from the Files table) and bumps the example pin to `v3.1.0`.
   - `lib/glossarist/tasks/sync_model.rb`: adds `require "time"` so `Time#iso8601` in `write_source_manifest` doesn't depend on ActiveSupport being loaded transitively.

## Audit findings (no action in this PR — called out for visibility)

Architectural health is generally good. Items worth tracking as follow-ups:

### Coverage gaps from v3.1.0 sync
- **Dataset-level NonVerbalEntity RDF** — glossarist-ruby's `ConceptToGlossTransform` does not yet emit `gloss:Figure` / `gloss:Table` / `gloss:Formula` instances for dataset-level entities. The shapes are vendored; the emission path is missing.
- **Reified DesignationRelationship** — emitter uses the direct predicate `gloss:abbreviatedFormFor`; v3.1.0 ontology declares `gloss:hasDesignationRelationship` → `gloss:DesignationRelationship` node model. Not a SHACL violation today (new shapes don't require the reified form), but worth aligning.

### Pre-existing architectural smells
- **`RegisterData#to_h` and `#[]`** (`lib/glossarist/register_data.rb:67,41`) — hand-rolled hash serialization. The class extends `Lutaml::Model::Serializable`, so `to_hash` is provided by the framework. Per the global "NEVER hand-roll serialization" rule, this is tech debt.
- **`ConceptToGlossTransform#designation_instance_for`** (`lib/glossarist/transforms/concept_to_gloss_transform.rb:167`) — type-dispatch `case/when` over Designation subclasses. OCP violation: adding a new Designation subclass requires editing this method. Could be a registry pattern where each Designation class registers its RDF counterpart.
- **`DATE_TYPE_MAP`** (`concept_to_gloss_transform.rb:23`) — hardcoded 3-entry map. Could be derived from `config.yml`.
- **Validation rule spec coverage** — 23 of 44 validation rules lack dedicated `_spec.rb` files. Some are covered indirectly via `dataset_validator_spec.rb`, but per-rule focused tests would catch regressions faster.

## Test plan

- [x] `bundle exec rspec spec/unit/rdf/ spec/unit/tasks/shacl_validator_spec.rb` — 184 examples, 0 failures
- [x] `bundle exec rspec spec/unit/tasks/` — 6 examples, 0 failures
- [x] `bundle exec rake glossarist:sync:model[v3.1.0]` — re-runs cleanly, SOURCE.json records `v3.1.0`
- [x] Vendored data files unchanged from prior SHA pin (byte-identical)
