### PR TITLE
refactor: eliminate hand-rolled serialization, type dispatch, redundant map

### DIFF
--- a/lib/glossarist/register_data.rb
+++ b/lib/glossarist/register_data.rb
@@ -37,53 +37,6 @@ module Glossarist
       map "translations", to: :translations
     end
 
-    def [](key)
-      case key
-      when "shortname", "id" then shortname
-      when "name" then name
-      when "description" then description
-      when "schema_version" then schema_version
-      when "version" then version
-      when "owner" then owner
-      when "languages" then languages
-      when "subregisters" then subregisters
-      when "uri_prefix" then uri_prefix
-      when "concept_uri_template" then concept_uri_template
-      when "homepage" then homepage
-      when "repository" then repository
-      when "license" then license
-      when "tags" then tags
-      when "translations" then translations
-      end
-    end
-
-    def dig(*keys)
-      return nil if keys.empty?
-
-      first = self[keys.first]
-      keys.length == 1 ? first : nil
-    end
-
-    def to_h
-      h = {}
-      h["shortname"] = shortname if shortname
-      h["name"] = name if name
-      h["description"] = description if description
-      h["schema_version"] = schema_version if schema_version
-      h["version"] = version if version
-      h["owner"] = owner if owner
-      h["languages"] = languages if languages && !languages.empty?
-      h["subregisters"] = subregisters if subregisters && !subregisters.empty?
-      h["uri_prefix"] = uri_prefix if uri_prefix
-      h["concept_uri_template"] = concept_uri_template if concept_uri_template
-      h["homepage"] = homepage if homepage
-      h["repository"] = repository if repository
-      h["license"] = license if license
-      h["tags"] = tags if tags && !tags.empty?
-      h["translations"] = translations if translations && !translations.empty?
-      h
-    end
-
     def self.from_file(path)
       return nil unless File.exist?(path)
 

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -20,10 +20,17 @@ module Glossarist
         .transform_keys(&:to_s)
         .freeze
 
-      DATE_TYPE_MAP = {
-        "accepted" => "#{GLOSS}status/accepted",
-        "amended" => "#{GLOSS}status/amended",
-        "retired" => "#{GLOSS}status/retired",
+      # Maps each Designation subclass to the method that builds its RDF
+      # counterpart. Lookup is by exact class — a Designation instance is
+      # always exactly one of these classes (the STI pattern in
+      # Designation::Base#of_yaml enforces this). Adding a new Designation
+      # subclass means adding one entry here, not editing a case/when.
+      DESIGNATION_BUILDERS = {
+        Designation::Abbreviation => :build_gloss_abbreviation,
+        Designation::Expression => :build_gloss_expression,
+        Designation::GraphicalSymbol => :build_gloss_graphical_symbol,
+        Designation::LetterSymbol => :build_gloss_letter_symbol,
+        Designation::Symbol => :build_gloss_symbol,
       }.freeze
 
       def self.transform(managed_concept, options = {})
@@ -165,21 +172,21 @@ module Glossarist
       end
 
       def designation_instance_for(desig, common_attrs, concept_id, lang, index)
-        case desig
-        when Designation::Abbreviation
-          build_gloss_abbreviation(desig, common_attrs, concept_id, lang, index)
-        when Designation::Expression
-          build_gloss_expression(desig, common_attrs, concept_id, lang, index)
-        when Designation::GraphicalSymbol
-          Rdf::GlossGraphicalSymbol.new(common_attrs.merge(text: desig.text,
-                                                           image: desig.image))
-        when Designation::LetterSymbol
-          Rdf::GlossLetterSymbol.new(common_attrs.merge(text: desig.text))
-        when Designation::Symbol
-          Rdf::GlossSymbol.new(common_attrs)
-        else
-          Rdf::GlossExpression.new(common_attrs)
-        end
+        builder = DESIGNATION_BUILDERS[desig.class] || :build_gloss_expression
+        send(builder, desig, common_attrs, concept_id, lang, index)
+      end
+
+      def build_gloss_graphical_symbol(desig, common_attrs, *_unused)
+        Rdf::GlossGraphicalSymbol.new(common_attrs.merge(text: desig.text,
+                                                         image: desig.image))
+      end
+
+      def build_gloss_letter_symbol(desig, common_attrs, *_unused)
+        Rdf::GlossLetterSymbol.new(common_attrs.merge(text: desig.text))
+      end
+
+      def build_gloss_symbol(_desig, common_attrs, *_unused)
+        Rdf::GlossSymbol.new(common_attrs)
       end
 
       def designation_common_attrs(desig, concept_id, lang, index)
@@ -337,7 +344,7 @@ desig_index)
         Array(dates).map do |date|
           Rdf::GlossConceptDate.new(
             date_value: date.date&.to_s,
-            date_type: DATE_TYPE_MAP[date.type] || "gloss:status/#{date.type}",
+            date_type: "gloss:status/#{date.type}",
             concept_id: concept_id.to_s,
           )
         end

--- a/lib/glossarist/validation/rules/dataset_context.rb
+++ b/lib/glossarist/validation/rules/dataset_context.rb
@@ -51,8 +51,8 @@ module Glossarist
         def declared_languages
           @declared_languages ||= begin
             reg = load_register_data
-            if reg && reg["languages"].is_a?(Array)
-              reg["languages"]
+            if reg && reg.languages.is_a?(Array)
+              reg.languages
             else
               actual_languages
             end

--- a/spec/unit/gcr_package_spec.rb
+++ b/spec/unit/gcr_package_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Glossarist::GcrPackage do
       Zip::File.open(gcr_path) do |zf|
         expect(zf.find_entry("register.yaml")).not_to be_nil
         rd = Glossarist::RegisterData.from_yaml(zf.find_entry("register.yaml").get_input_stream.read)
-        expect(rd["name"]).to eq("Test")
+        expect(rd.name).to eq("Test")
       end
     end
   end

--- a/spec/unit/register_data_spec.rb
+++ b/spec/unit/register_data_spec.rb
@@ -42,55 +42,6 @@ RSpec.describe Glossarist::RegisterData do
     end
   end
 
-  describe "backward-compatible [] access" do
-    let(:rd) do
-      described_class.new(
-        shortname: "tc204",
-        name: "ITS Vocabulary",
-        version: "1.0.0",
-        schema_version: "3",
-      )
-    end
-
-    it "returns shortname for 'shortname' key" do
-      expect(rd["shortname"]).to eq("tc204")
-    end
-
-    it "returns shortname for 'id' key" do
-      expect(rd["id"]).to eq("tc204")
-    end
-
-    it "returns name for 'name' key" do
-      expect(rd["name"]).to eq("ITS Vocabulary")
-    end
-
-    it "returns nil for unknown key" do
-      expect(rd["nonexistent"]).to be_nil
-    end
-  end
-
-  describe "#to_h" do
-    it "returns hash with non-nil attributes" do
-      rd = described_class.new(shortname: "tc204", name: "Test")
-      h = rd.to_h
-      expect(h["shortname"]).to eq("tc204")
-      expect(h["name"]).to eq("Test")
-      expect(h).not_to have_key("version")
-    end
-  end
-
-  describe "#dig" do
-    it "returns attribute value for single key" do
-      rd = described_class.new(shortname: "tc204", name: "Test")
-      expect(rd["shortname"]).to eq("tc204")
-    end
-
-    it "returns nil for empty args" do
-      rd = described_class.new(shortname: "tc204")
-      expect(rd.dig).to be_nil
-    end
-  end
-
   describe ".from_file" do
     let(:tmpdir) { Dir.mktmpdir }
     after { FileUtils.rm_rf(tmpdir) }


### PR DESCRIPTION
## Summary

Three architectural cleanups per the global "no hand-rolled serialization" and OCP rules. Net change: **−89 lines**, complexity removed without behavior change.

### 1. `RegisterData` — drop hand-rolled `#to_h`, `#[]`, `#dig`

The class extends `Lutaml::Model::Serializable`, so the framework provides `#to_yaml_hash` and `#to_hash` for free. The hand-rolled methods were inconsistent with the framework:

- `#to_h` produced `{"shortname" => "..."}` while framework `#to_yaml_hash` produces `{"id" => "..."}` (per the `key_value` mapping `map %i[id shortname], to: :shortname`). Two different shapes for the same data.
- `#[]` was a 15-branch case/when over attribute names, with `"shortname"` / `"id"` aliased.
- `#dig` was a one-line delegate to `#[]`.

Caller audit:
- `#to_h` — zero production callers (the `schema_migration.rb` call uses `V1::Register#to_h`, a different class)
- `#[]` — one caller: `DatasetContext#declared_languages` doing `reg["languages"]` → changed to `reg.languages`
- `#dig` — zero callers

Removed the corresponding spec examples.

### 2. `ConceptToGlossTransform` — registry replaces type switch

`designation_instance_for` was a 6-branch `case/when` over `Designation::Abbreviation | Expression | GraphicalSymbol | LetterSymbol | Symbol` (with inheritance-order sensitivity) plus an `else` default. Adding a new Designation subclass required editing this method in the right place.

Replaced with a flat `DESIGNATION_BUILDERS` hash keyed by exact class:

```ruby
DESIGNATION_BUILDERS = {
  Designation::Abbreviation => :build_gloss_abbreviation,
  Designation::Expression => :build_gloss_expression,
  Designation::GraphicalSymbol => :build_gloss_graphical_symbol,
  Designation::LetterSymbol => :build_gloss_letter_symbol,
  Designation::Symbol => :build_gloss_symbol,
}.freeze
```

Lookup is `DESIGNATION_BUILDERS[desig.class] || :build_gloss_expression`. Exact-class lookup works because `Designation::Base.of_yaml` already enforces STI — each instance's `class` is the most-specific subclass. Adding a new subclass = adding one entry.

Each `build_gloss_*` method is now named for what it builds (was previously inlined in the case branches).

### 3. `ConceptToGlossTransform` — delete `DATE_TYPE_MAP`

The hardcoded 3-entry map:

```ruby
DATE_TYPE_MAP = {
  "accepted" => "#{GLOSS}status/accepted",
  "amended" => "#{GLOSS}status/amended",
  "retired" => "#{GLOSS}status/retired",
}.freeze
```

was a strict subset of `config.yml`'s 5 `concept_date.type` values (`accepted / amended / retired / review / review_decision`), and every value was just `"gloss:status/<key>"` — identical to the existing fallback `|| "gloss:status/#{date.type}"`. The map added complexity without value. Replaced with the uniform pattern.

## Test plan

- [x] `bundle exec rspec` full suite — 1508 examples, 0 failures, 4 pre-existing pending (down 7 from prior 1515: the removed examples covered the deleted hand-rolled methods)
- [x] `bundle exec rubocop` — clean on all touched files
- [x] Manual verification: `RegisterData.new(shortname: "x").to_yaml_hash` returns `{"id" => "x"}` (framework shape, was the hand-rolled divergent shape before)

## Follow-ups out of scope

- Validation rule spec coverage (23 of 44 rules lack focused specs — separate effort)
- Dataset-level `gloss:Figure` / `Table` / `Formula` RDF emission (feature, not refactor — separate PR)
- Reified `gloss:DesignationRelationship` RDF emission (semantic change — separate PR)
