### PR TITLE
fix(loader): preserve V3 fields when loading legacy concept/ layout

### DIFF
--- a/lib/glossarist/glossary_store.rb
+++ b/lib/glossarist/glossary_store.rb
@@ -269,7 +269,11 @@ module Glossarist
     end
 
     def load_legacy_localizations(managed_concept, lc_index, version = "3")
-      l10n_class = version.to_s == "2" ? V2::LocalizedConcept : LocalizedConcept
+      l10n_class = case version.to_s
+                   when "2" then V2::LocalizedConcept
+                   when "3" then V3::LocalizedConcept
+                   else LocalizedConcept
+                   end
       lc_map = managed_concept.data.localized_concepts || {}
       lc_map.each_value do |uuid|
         lc_file = lc_index[uuid]
@@ -344,7 +348,7 @@ module Glossarist
     end
 
     def detect_version(raw)
-      if (m = raw.match(/^schema_version:\s*v?(\d)/))
+      if (m = raw.match(/^schema_version:\s*['"]?v?(\d)/))
         m[1]
       else
         "2"

--- a/spec/unit/glossary_store_spec.rb
+++ b/spec/unit/glossary_store_spec.rb
@@ -189,6 +189,84 @@ RSpec.describe Glossarist::GlossaryStore do
     end
   end
 
+  describe "legacy V3 concept/ + localized_concept/ layout" do
+    # Regression: when a V3 dataset uses the legacy split layout
+    # (concept/{id}.yaml + localized_concept/{uuid}.yaml), the loader
+    # must dispatch to V3::LocalizedConcept — not the base
+    # LocalizedConcept — so V3 ConceptData fields (annotations,
+    # scoped examples, etc.) parse correctly. Before the fix, the
+    # legacy loader unconditionally picked the base class for any
+    # version other than "2", silently dropping V3-specific fields.
+    let(:v3_concept_yaml) do
+      <<~YAML
+        ---
+        data:
+          identifier: "1.1"
+          localized_concepts:
+            eng: lc-1-1-eng
+        status: valid
+        schema_version: '3'
+        id: c-1-1
+      YAML
+    end
+
+    let(:v3_l10n_yaml) do
+      <<~YAML
+        ---
+        data:
+          definition:
+          - content: a concept with annotations
+          terms:
+          - type: expression
+            normative_status: preferred
+            designation: annotated term
+          notes:
+          - content: a note
+          examples:
+          - content: an example
+          annotations:
+          - content: editorial annotation about the entry
+          language_code: eng
+          entry_status: valid
+        id: lc-1-1-eng
+      YAML
+    end
+
+    let(:v3_legacy_dir) do
+      dir = File.join(tmpdir, "v3-legacy")
+      concept_dir = File.join(dir, "concept")
+      lc_dir = File.join(dir, "localized_concept")
+      FileUtils.mkdir_p(concept_dir)
+      FileUtils.mkdir_p(lc_dir)
+      File.write(File.join(concept_dir, "c-1-1.yaml"), v3_concept_yaml,
+                 encoding: "utf-8")
+      File.write(File.join(lc_dir, "lc-1-1-eng.yaml"), v3_l10n_yaml,
+                 encoding: "utf-8")
+      dir
+    end
+
+    it "dispatches to V3::LocalizedConcept for schema_version 3" do
+      store.load(v3_legacy_dir)
+      mc = store.concepts.first
+      l10n = mc.localization("eng")
+
+      expect(l10n).to be_a(Glossarist::V3::LocalizedConcept)
+      expect(l10n.data).to be_a(Glossarist::V3::ConceptData)
+    end
+
+    it "preserves V3 ConceptData fields including annotations" do
+      store.load(v3_legacy_dir)
+      mc = store.concepts.first
+      l10n = mc.localization("eng")
+
+      expect(l10n.data.annotations.map(&:content)).to(
+        eq(["editorial annotation about the entry"]),
+      )
+      expect(l10n.data.notes.map(&:content)).to eq(["a note"])
+      expect(l10n.data.examples.map(&:content)).to eq(["an example"])
+    end
+  end
+
   describe "#concepts" do
     it "returns ManagedConcept instances" do
       store.load_directory(glossary_dir)


### PR DESCRIPTION
## Summary

Fixes the actual root cause behind metanorma-plugin-glossarist TODO 15 ("concept-level annotations — BLOCKED UPSTREAM"). The TODO's premise was wrong: concept-model v3.1.0 only declares annotations on `LocalizedConcept` (per the ontology's `rdfs:domain gloss:LocalizedConcept` and the `localized-concept.yaml` schema), and glossarist-ruby already models them correctly on `V3::ConceptData`. The real blocker was two compounding loader bugs that silently dropped V3 fields when a V3 dataset used the legacy split layout.

### The bugs

1. **`detect_version` regex missed quoted values.**
   ```ruby
   /^schema_version:\s*v?(\d)/
   ```
   matched `schema_version: 3` but not `schema_version: '3'` or `schema_version: "3"` — the forms YAML round-trips actually produce. Files with quoted `schema_version` fell through to the `"2"` default, so V3 fixtures were treated as V2.

2. **`load_legacy_localizations` only dispatched V2 vs base.**
   ```ruby
   l10n_class = version.to_s == "2" ? V2::LocalizedConcept : LocalizedConcept
   ```
   meant any version other than `"2"` (including `"3"`) got the base `LocalizedConcept`, whose `ConceptData` lacks typed `annotations`, V3 `examples` shape, scoped examples, etc. Fields were silently lost — no error, no warning, just empty collections at runtime.

### The fixes

- `detect_version` regex allows an optional quote character before the optional `v` prefix: `/^schema_version:\s*['"]?v?(\d)/`. Handles `3`, `'3'`, `"3"`, `v3`, `'v3'`.
- `load_legacy_localizations` uses a `case/when` mapping `"3" → V3::LocalizedConcept`, `"2" → V2::LocalizedConcept`, `else → LocalizedConcept` (legacy fallback for unknown versions).

### Verification

End-to-end against the plugin's actual fixture (`spec/fixtures/dataset-glossarist-v3/concept/c-1.1.yaml`), loaded via `ManagedConceptCollection#load_from_files`:

```
L10n class: Glossarist::V3::LocalizedConcept   # was: Glossarist::LocalizedConcept (base)
Data class: Glossarist::V3::ConceptData         # was: Glossarist::ConceptData (base)
Annotations content: ["This concept is used as a parent in the test hierarchy."]  # was: []
```

### Downstream impact

Once this ships, metanorma-plugin-glossarist can:
1. Remove the `skip "V3 annotations not parsed by this glossarist version"` guard in `bibliography_renderer_spec.rb`
2. Close TODO 15 with the corrected diagnosis (not a missing ManagedConceptData attribute; was a loader bug)
3. The Liquid template `{% for annotation in l10n.data.annotations.definitions %}` block in `_concept.liquid` will work end-to-end

## Test plan

- [x] Two new regression specs in `spec/unit/glossary_store_spec.rb` under `"legacy V3 concept/ + localized_concept/ layout"`:
  - `dispatches to V3::LocalizedConcept for schema_version 3`
  - `preserves V3 ConceptData fields including annotations`
- [x] `bundle exec rspec` full suite — 1510 examples, 0 failures, 4 pre-existing pending
- [x] `bundle exec rubocop` — clean
- [x] End-to-end against metanorma-plugin-glossarist fixture (output above)
