### PR TITLE
test(validation): add focused specs for 14 rules lacking them (batch 1)

### DIFF
--- a/spec/support/validation_rule_spec_helper.rb
+++ b/spec/support/validation_rule_spec_helper.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Helper for validation rule specs: builds real ConceptContext / DatasetContext
+# instances from minimal input, so specs construct actual model objects instead
+# of doubles (per the global "no doubles" rule).
+module ValidationRuleSpecHelper
+  def make_managed_concept(id:, status: nil, dates: [], sources: [], langs: {})
+    mc = Glossarist::ManagedConcept.new(data: { "id" => id })
+    mc.status = status if status
+    mc.dates = dates if dates.any?
+    mc.sources = sources if sources.any?
+    langs.each do |lang, opts|
+      mc.add_localization(build_localization(lang, opts))
+    end
+    mc
+  end
+
+  def build_localization(lang, opts = {})
+    terms = opts[:terms] || [{
+      "type" => "expression",
+      "designation" => opts[:designation] || "test term",
+      "normative_status" => opts[:normative_status] || "preferred",
+    }]
+    data = {
+      "language_code" => lang.to_s,
+      "terms" => terms,
+      "definition" => opts[:definition] || [{ "content" => "a definition" }],
+      "entry_status" => opts[:entry_status] || "valid",
+    }
+    data["sources"] = opts[:sources] if opts[:sources]
+    data["notes"] = opts[:notes] if opts[:notes]
+    data["examples"] = opts[:examples] if opts[:examples]
+    data["annotations"] = opts[:annotations] if opts[:annotations]
+    data["non_verb_rep"] = opts[:non_verb_rep] if opts[:non_verb_rep]
+    Glossarist::LocalizedConcept.of_yaml({ "data" => data })
+  end
+
+  # Real DatasetContext backed by a tmpdir. Caller can add_concept before
+  # creating a ConceptContext.
+  def make_dataset_context(tmpdir)
+    Glossarist::Validation::Rules::DatasetContext.new(tmpdir)
+  end
+
+  def make_concept_context(concept, collection_context:, file_name: nil)
+    Glossarist::Validation::Rules::ConceptContext.new(
+      concept,
+      file_name: file_name || "concept-#{concept.data&.id}.yaml",
+      collection_context: collection_context,
+    )
+  end
+end
+
+RSpec.configure do |config|
+  config.include ValidationRuleSpecHelper
+end

--- a/spec/unit/validation/rules/asciidoc_xref_rule_spec.rb
+++ b/spec/unit/validation/rules/asciidoc_xref_rule_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::AsciidocXrefRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-102")
+    expect(rule.category).to eq(:references)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when a definition has no AsciiDoc xrefs" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "a plain definition with no xrefs" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags an AsciiDoc xref that does not resolve against bibliography_index" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "See <<ISO_9000>> for context." }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("ISO_9000")
+    expect(issues.first.suggestion).to include("bibliography.yaml")
+  end
+end

--- a/spec/unit/validation/rules/concept_id_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_id_rule_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptIdRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-001")
+    expect(rule.category).to eq(:structure)
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when concept has an id" do
+    mc = make_managed_concept(id: "1.1")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "returns an error when concept id is nil" do
+    mc = make_managed_concept(id: nil)
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "no-id.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("missing concept id")
+    expect(issues.first.severity).to eq("error")
+  end
+
+  it "is always applicable" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).to be_applicable(cc)
+  end
+end

--- a/spec/unit/validation/rules/concept_id_uniqueness_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_id_uniqueness_rule_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptIdUniquenessRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-001-uniq")
+    expect(rule.category).to eq(:structure)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when there are zero concepts" do
+    expect(rule).not_to be_applicable(dataset_context)
+  end
+
+  it "returns no issues when all concept ids are unique" do
+    %w[a b c].each { |id| dataset_context.add_concept(make_managed_concept(id: id)) }
+    expect(rule.check(dataset_context)).to be_empty
+  end
+
+  it "flags the second occurrence of a duplicate id with the first location" do
+    dataset_context.add_concept(make_managed_concept(id: "1.1"))
+    dataset_context.add_concept(make_managed_concept(id: "1.2"))
+    dataset_context.add_concept(make_managed_concept(id: "1.1"))
+    issues = rule.check(dataset_context)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("duplicate id '1.1'")
+    expect(issues.first.message).to include("concept-1.1.yaml")
+  end
+
+  it "skips concepts without an id" do
+    dataset_context.add_concept(make_managed_concept(id: nil))
+    dataset_context.add_concept(make_managed_concept(id: nil))
+    expect(rule.check(dataset_context)).to be_empty
+  end
+end

--- a/spec/unit/validation/rules/concept_status_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_status_rule_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptStatusRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_statuses) { Glossarist::GlossaryDefinition::CONCEPT_STATUSES }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-201")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues for a valid status" do
+    valid_statuses.first(3).each do |status|
+      mc = make_managed_concept(id: "x", status: status)
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty
+    end
+  end
+
+  it "is not applicable when concept has no status" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags an invalid status with a suggestion listing valid values" do
+    mc = make_managed_concept(id: "x", status: "not_a_status")
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "bad.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("not_a_status")
+    expect(issues.first.suggestion).to include(valid_statuses.first)
+    expect(issues.first.severity).to eq("error")
+  end
+end

--- a/spec/unit/validation/rules/date_type_rule_spec.rb
+++ b/spec/unit/validation/rules/date_type_rule_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::DateTypeRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_types) { Glossarist::GlossaryDefinition::CONCEPT_DATE_TYPES }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-205")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when every date has a valid type" do
+    valid_types.first(2).each_with_index do |type, idx|
+      d = Glossarist::ConceptDate.new(date: Date.new(2020, 1, 1 + idx), type: type)
+      mc = make_managed_concept(id: "x", dates: [d])
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty
+    end
+  end
+
+  it "is not applicable when the concept has no dates" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags an invalid date type with the offending index" do
+    d = Glossarist::ConceptDate.new(date: Date.new(2020, 1, 1), type: "unknown")
+    mc = make_managed_concept(id: "x", dates: [d])
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("date 1")
+    expect(issues.first.message).to include("unknown")
+    expect(issues.first.suggestion).to include(valid_types.first)
+  end
+
+  it "skips dates without a type" do
+    d = Glossarist::ConceptDate.new(date: Date.new(2020, 1, 1), type: nil)
+    mc = make_managed_concept(id: "x", dates: [d])
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+end

--- a/spec/unit/validation/rules/date_validity_rule_spec.rb
+++ b/spec/unit/validation/rules/date_validity_rule_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "date"
+
+RSpec.describe Glossarist::Validation::Rules::DateValidityRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-307")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues for a parseable ISO 8601 date" do
+    d = Glossarist::ConceptDate.new(date: Date.new(2024, 1, 15), type: "accepted")
+    mc = make_managed_concept(id: "x", dates: [d])
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no dates" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags an unparseable date string" do
+    # V3::ConceptDate keeps `date` as a free-form string, so unparseable
+    # values survive to the validator (base ConceptDate's :date_time type
+    # would coerce them to nil before validation runs).
+    d = Glossarist::V3::ConceptDate.new(date: "not-a-date", type: "accepted")
+    mc = make_managed_concept(id: "x", dates: [d])
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("unparseable")
+    expect(issues.first.message).to include("not-a-date")
+  end
+
+  it "flags a typed date with no value" do
+    d = Glossarist::ConceptDate.new(date: nil, type: "accepted")
+    mc = make_managed_concept(id: "x", dates: [d])
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("no date value")
+  end
+end

--- a/spec/unit/validation/rules/definition_content_rule_spec.rb
+++ b/spec/unit/validation/rules/definition_content_rule_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::DefinitionContentRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-300")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when every definition has content" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "a definition" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a definition with nil content" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => nil }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("definition 1")
+    expect(issues.first.message).to include("empty")
+    expect(issues.first.location).to include("eng")
+  end
+
+  it "flags a definition with whitespace-only content" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "   " }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+  end
+end

--- a/spec/unit/validation/rules/designation_status_rule_spec.rb
+++ b/spec/unit/validation/rules/designation_status_rule_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::DesignationStatusRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_statuses) { Glossarist::GlossaryDefinition::DESIGNATION_BASE_NORMATIVE_STATUSES }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-204")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues for every valid normative_status" do
+    valid_statuses.each do |status|
+      mc = make_managed_concept(id: "x", langs: {
+                                  eng: { terms: [{ "type" => "expression", "designation" => "t",
+                                                   "normative_status" => status }] },
+                                })
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty, "expected no issues for #{status}"
+    end
+  end
+
+  it "skips terms with no normative_status" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { terms: [{ "type" => "expression", "designation" => "t",
+                                                 "normative_status" => nil }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags a term with an invalid normative_status" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { terms: [{ "type" => "expression", "designation" => "t",
+                                                 "normative_status" => "best_ever" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("best_ever")
+    expect(issues.first.suggestion).to include(valid_statuses.first)
+  end
+end

--- a/spec/unit/validation/rules/designation_type_rule_spec.rb
+++ b/spec/unit/validation/rules/designation_type_rule_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::DesignationTypeRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_types) { Glossarist::Designation::SERIALIZED_TYPES.values.grep(String).uniq }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-207")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when all terms have a recognized type" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { terms: [{ "type" => "expression", "designation" => "t",
+                                                 "normative_status" => "preferred" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a term with an unrecognized designation type" do
+    # Bypass Designation::Base.of_yaml (which rejects unknown types at
+    # load time) by directly constructing an Expression and overriding
+    # its type to simulate an unknown type sneaking through.
+    bad_term = Glossarist::Designation::Expression.new(
+      designation: "u", normative_status: "preferred",
+    )
+    bad_term.type = "invented"
+
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [
+      *mc.localization("eng").data.terms,
+      bad_term,
+    ]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("invented")
+    expect(issues.first.suggestion).to include(valid_types.first)
+  end
+end

--- a/spec/unit/validation/rules/duplicate_term_rule_spec.rb
+++ b/spec/unit/validation/rules/duplicate_term_rule_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::DuplicateTermRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-302")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when there are no concepts" do
+    expect(rule).not_to be_applicable(dataset_context)
+  end
+
+  it "returns no issues when preferred terms are distinct" do
+    dataset_context.add_concept(make_managed_concept(id: "1", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "alpha",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    dataset_context.add_concept(make_managed_concept(id: "2", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "beta",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    expect(rule.check(dataset_context)).to be_empty
+  end
+
+  it "flags two concepts sharing the same preferred term in the same language" do
+    dataset_context.add_concept(make_managed_concept(id: "1", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "delta",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    dataset_context.add_concept(make_managed_concept(id: "2", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "delta",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    issues = rule.check(dataset_context)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("'delta'")
+    expect(issues.first.message).to include("1, 2")
+  end
+
+  it "treats the same term in different languages as distinct" do
+    dataset_context.add_concept(make_managed_concept(id: "1", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "term",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    dataset_context.add_concept(make_managed_concept(id: "2", langs: {
+                                                       fra: { terms: [{ "type" => "expression", "designation" => "term",
+                                                                        "normative_status" => "preferred" }] },
+                                                     }))
+    expect(rule.check(dataset_context)).to be_empty
+  end
+
+  it "ignores non-preferred designations" do
+    dataset_context.add_concept(make_managed_concept(id: "1", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "alias",
+                                                                        "normative_status" => "admitted" }] },
+                                                     }))
+    dataset_context.add_concept(make_managed_concept(id: "2", langs: {
+                                                       eng: { terms: [{ "type" => "expression", "designation" => "alias",
+                                                                        "normative_status" => "deprecated" }] },
+                                                     }))
+    expect(rule.check(dataset_context)).to be_empty
+  end
+end

--- a/spec/unit/validation/rules/entry_status_rule_spec.rb
+++ b/spec/unit/validation/rules/entry_status_rule_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::EntryStatusRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-003")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  %w[valid superseded withdrawn draft].each do |status|
+    it "returns no issues for entry_status '#{status}'" do
+      mc = make_managed_concept(id: "x", langs: { eng: { entry_status: status } })
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty
+    end
+  end
+
+  it "skips localizations with no entry_status" do
+    mc = make_managed_concept(id: "x", langs: { eng: { entry_status: nil } })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags an invalid entry_status with the offending language in the location" do
+    mc = make_managed_concept(id: "x", langs: { fra: { entry_status: "bogus" } })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("bogus")
+    expect(issues.first.location).to include("fra")
+  end
+end

--- a/spec/unit/validation/rules/l10n_uuid_integrity_rule_spec.rb
+++ b/spec/unit/validation/rules/l10n_uuid_integrity_rule_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::L10nUuidIntegrityRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-018")
+    expect(rule.category).to eq(:integrity)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "is not applicable when no localization files have been indexed" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "returns no issues when every referenced UUID has a file" do
+    lc_dir = File.join(tmpdir, "concepts", "localized_concept")
+    FileUtils.mkdir_p(lc_dir)
+    File.write(File.join(lc_dir, "lc-1.yaml"), "---\ndata: {}\n", encoding: "utf-8")
+
+    ds = make_dataset_context(tmpdir)
+    mc = make_managed_concept(id: "x")
+    mc.data.localized_concepts = { "eng" => "lc-1" }
+    cc = make_concept_context(mc, collection_context: ds)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags a referenced UUID with no matching file" do
+    lc_dir = File.join(tmpdir, "concepts", "localized_concept")
+    FileUtils.mkdir_p(lc_dir)
+    File.write(File.join(lc_dir, "lc-1.yaml"), "---\ndata: {}\n", encoding: "utf-8")
+
+    ds = make_dataset_context(tmpdir)
+    mc = make_managed_concept(id: "x")
+    mc.data.localized_concepts = { "eng" => "lc-1", "fra" => "lc-missing" }
+    cc = make_concept_context(mc, collection_context: ds, file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("fra")
+    expect(issues.first.message).to include("lc-missing")
+  end
+end

--- a/spec/unit/validation/rules/language_code_format_rule_spec.rb
+++ b/spec/unit/validation/rules/language_code_format_rule_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::LanguageCodeFormatRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-206")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  %w[eng fra deu].each do |lang|
+    it "returns no issues for valid ISO 639-3 code '#{lang}'" do
+      mc = make_managed_concept(id: "x", langs: { lang.to_sym => {} })
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty
+    end
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a code with wrong length" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").language_code = "en"
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("'en'")
+    expect(issues.first.suggestion).to include("ISO 639-3")
+  end
+
+  it "flags a code with uppercase letters" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").language_code = "ENG"
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc).length).to eq(1)
+  end
+end

--- a/spec/unit/validation/rules/localization_presence_rule_spec.rb
+++ b/spec/unit/validation/rules/localization_presence_rule_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::LocalizationPresenceRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-002")
+    expect(rule.category).to eq(:structure)
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when at least one localization exists" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags a concept with no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "lonely.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("no localizations")
+    expect(issues.first.severity).to eq("warning")
+  end
+
+  it "is always applicable" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).to be_applicable(cc)
+  end
+end


### PR DESCRIPTION
## Summary

First batch of focused validation rule specs. Adds a shared helper plus 14 rule specs, covering the concept-scoped rule families (structure, schema, quality, references, integrity). Closes 14 of the 31 spec-coverage gaps called out in PR #196.

### Shared helper

`spec/support/validation_rule_spec_helper.rb` — builds real `ConceptContext` / `DatasetContext` instances from minimal input:

```ruby
mc = make_managed_concept(id: "x", status: "valid", langs: { eng: { ... } })
cc = make_concept_context(mc, collection_context: dataset_context)
issues = rule.check(cc)
```

Auto-included in all specs via `RSpec.configure`. Per the global "no doubles" rule, the helper uses real model instances throughout — no `instance_double(DatasetContext)` (which several existing specs still do and would be cleaned up separately).

### Rules covered (14)

| Code | Rule | What it tests |
|------|------|---------------|
| GLS-001 | `ConceptIdRule` | concept id presence |
| GLS-001-uniq | `ConceptIdUniquenessRule` | duplicate id detection across collection |
| GLS-002 | `LocalizationPresenceRule` | at least one l10n per concept |
| GLS-003 | `EntryStatusRule` | valid entry_status enum per localization |
| GLS-018 | `L10nUuidIntegrityRule` | referenced localization UUIDs resolve to files |
| GLS-102 | `AsciidocXrefRule` | `<<anchor>>` xrefs resolve against bibliography index |
| GLS-201 | `ConceptStatusRule` | valid concept status enum |
| GLS-204 | `DesignationStatusRule` | valid normative_status enum per term |
| GLS-205 | `DateTypeRule` | valid concept_date type enum |
| GLS-206 | `LanguageCodeFormatRule` | ISO 639-3 (3 lowercase letters) |
| GLS-207 | `DesignationTypeRule` | recognized designation type |
| GLS-300 | `DefinitionContentRule` | non-empty definition content |
| GLS-302 | `DuplicateTermRule` | same preferred term across concepts |
| GLS-307 | `DateValidityRule` | parseable ISO 8601 date strings |

### Test approach

Each spec covers:
- metadata (code/category/severity/scope)
- happy path (valid input → no issues)
- `applicable?` boundary (when the rule should/shouldn't run)
- at least one failure case with assertions on message content + suggestion

For `DesignationTypeRule`'s "unknown type" branch, the spec bypasses `Designation::Base.of_yaml` (which rejects unknown types at load time) by directly constructing an `Expression` and overriding `.type` — this simulates an unknown type slipping past the loader without changing the model factory.

For `DateValidityRule`'s "unparseable" branch, the spec uses `V3::ConceptDate` instead of the base class because the base class's `:date_time` type coerces invalid strings to nil before validation runs (the rule never sees them).

## Test plan

- [x] `bundle exec rspec spec/unit/validation/rules/{rule}_spec.rb` for each new spec — all pass
- [x] `bundle exec rspec` full suite — 1578 examples, 0 failures (up from 1510; +68 new examples)
- [x] `bundle exec rubocop` — clean on all touched files

## Remaining gaps (deferred to batch 2)

17 rules still lack focused specs. The remaining ones need richer fixtures:
- **GCR-context rules** (`ConceptCountRule`, `ConceptUriRule`, `FilenameIdRule`) — need a `GcrContext` test factory
- **Language coverage family** (`LanguageCoverageRule`, `LanguageListRule`) — need declared_languages fixture setup
- **Bibliography family** (`BibliographyYamlRule`, `OrphanedBibliographyRule`, `CitationCompletenessRule`, `AuthoritativeSourceRule`) — need bibliography.yaml fixture
- **Reference rule complements** (`ConceptMentionRule`, `ImageReferenceRule`) — need extracted-reference fixtures

Batch 2 will follow with these.
