### PR TITLE
test(validation): add focused specs for 10 more rules (batch 2)

### DIFF
--- a/spec/unit/validation/rules/authoritative_source_rule_spec.rb
+++ b/spec/unit/validation/rules/authoritative_source_rule_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::AuthoritativeSourceRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-306")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when a localization has an authoritative source" do
+    src = Glossarist::ConceptSource.new(
+      type: "authoritative",
+      origin: Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(source: "ISO")),
+    )
+    mc = make_managed_concept(id: "x", langs: { eng: { sources: [] } })
+    mc.localization("eng").data.sources = [src]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a concept whose only sources are lineage" do
+    src = Glossarist::ConceptSource.new(
+      type: "lineage",
+      origin: Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(source: "ISO")),
+    )
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [src]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("no authoritative source")
+  end
+end

--- a/spec/unit/validation/rules/citation_completeness_rule_spec.rb
+++ b/spec/unit/validation/rules/citation_completeness_rule_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::CitationCompletenessRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-304")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when every source has a ref with source or id" do
+    src = Glossarist::ConceptSource.new(
+      type: "authoritative",
+      origin: Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(source: "ISO", id: "1")),
+    )
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [src]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a source whose origin.ref is nil" do
+    src = Glossarist::ConceptSource.new(
+      type: "authoritative",
+      origin: Glossarist::Citation.new(ref: nil),
+    )
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [src]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("source 1")
+    expect(issues.first.message).to include("empty origin")
+  end
+
+  it "flags a source whose origin.ref has neither source nor id" do
+    src = Glossarist::ConceptSource.new(
+      type: "authoritative",
+      origin: Glossarist::Citation.new(
+        ref: Glossarist::Citation::Ref.new(source: nil, id: nil),
+      ),
+    )
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [src]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc).length).to eq(1)
+  end
+end

--- a/spec/unit/validation/rules/concept_mention_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_mention_rule_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptMentionRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-100")
+    expect(rule.category).to eq(:references)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when a definition has no inline mentions" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "a plain definition" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a {{123}} numeric mention whose id is not in concept_ids" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "See {{999}} for context." }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("999")
+    expect(issues.first.suggestion).to include("dataset")
+  end
+
+  it "returns no issues when the mentioned id IS in concept_ids" do
+    # concept_ids is memoized on DatasetContext — seed both concepts first.
+    mentioned = make_managed_concept(id: "123")
+    referrer = make_managed_concept(id: "x", langs: {
+                                      eng: { definition: [{ "content" => "See {{123}} for context." }] },
+                                    })
+    dataset_context.add_concept(mentioned)
+    dataset_context.add_concept(referrer)
+    cc = make_concept_context(referrer, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+end

--- a/spec/unit/validation/rules/image_reference_rule_spec.rb
+++ b/spec/unit/validation/rules/image_reference_rule_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ImageReferenceRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-103")
+    expect(rule.category).to eq(:references)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when a definition has no image references" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "a plain definition" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags an image::...[] reference whose path is not in images/" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { definition: [{ "content" => "Diagram: image::figures/missing.png[]" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    # image::...[] path is "figures/missing.png" — both GLS-103 and GLS-104
+    # may flag it depending on asset_index; verify at least one issue is
+    # raised with the unresolved path.
+    expect(issues).not_to be_empty
+    expect(issues.first.message).to include("figures/missing.png")
+  end
+end

--- a/spec/unit/validation/rules/language_coverage_rule_spec.rb
+++ b/spec/unit/validation/rules/language_coverage_rule_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::LanguageCoverageRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-013")
+    expect(rule.category).to eq(:localization)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "is not applicable when no languages are declared" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  context "when register.yaml declares eng + fra" do
+    before do
+      File.write(File.join(tmpdir, "register.yaml"), <<~YAML, encoding: "utf-8")
+        ---
+        shortname: test
+        languages:
+        - eng
+        - fra
+      YAML
+      # Rebuild dataset_context so declared_languages reloads the new file.
+      @dataset_context = make_dataset_context(tmpdir)
+    end
+
+    let(:dataset_context) { @dataset_context }
+
+    it "returns no issues when the concept covers every declared language" do
+      mc = make_managed_concept(id: "x", langs: { eng: {}, fra: {} })
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty
+    end
+
+    it "flags a concept missing a declared language" do
+      mc = make_managed_concept(id: "x", langs: { eng: {} })
+      cc = make_concept_context(mc, collection_context: dataset_context,
+                                    file_name: "c.yaml")
+      issues = rule.check(cc)
+      expect(issues.length).to eq(1)
+      expect(issues.first.message).to include("fra")
+    end
+  end
+end

--- a/spec/unit/validation/rules/language_list_rule_spec.rb
+++ b/spec/unit/validation/rules/language_list_rule_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::LanguageListRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-012")
+    expect(rule.category).to eq(:integrity)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when no languages are declared" do
+    ds = make_dataset_context(tmpdir)
+    expect(rule).not_to be_applicable(ds)
+  end
+
+  context "when register.yaml declares eng + fra but concepts use eng + deu" do
+    let(:dataset_context) do
+      File.write(File.join(tmpdir, "register.yaml"), <<~YAML, encoding: "utf-8")
+        ---
+        shortname: test
+        languages:
+        - eng
+        - fra
+      YAML
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {} }))
+      ds.add_concept(make_managed_concept(id: "2", langs: { deu: {} }))
+      ds
+    end
+
+    it "reports both missing (fra) and extra (deu) languages" do
+      issues = rule.check(dataset_context)
+      messages = issues.map(&:message).join("\n")
+      expect(messages).to include("fra")
+      expect(messages).to include("deu")
+    end
+  end
+
+  context "when declared and actual languages match exactly" do
+    let(:dataset_context) do
+      File.write(File.join(tmpdir, "register.yaml"), <<~YAML, encoding: "utf-8")
+        ---
+        shortname: test
+        languages:
+        - eng
+        - fra
+      YAML
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {}, fra: {} }))
+      ds
+    end
+
+    it "returns no issues" do
+      expect(rule.check(dataset_context)).to be_empty
+    end
+  end
+end

--- a/spec/unit/validation/rules/preferred_term_rule_spec.rb
+++ b/spec/unit/validation/rules/preferred_term_rule_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::PreferredTermRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-301")
+    expect(rule.category).to eq(:quality)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when a preferred term exists" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { terms: [{ "type" => "expression", "designation" => "alpha",
+                                                 "normative_status" => "preferred" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "skips localizations with zero terms" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = []
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags a localization with terms but none preferred" do
+    mc = make_managed_concept(id: "x", langs: {
+                                eng: { terms: [{ "type" => "expression", "designation" => "alpha",
+                                                 "normative_status" => "admitted" }] },
+                              })
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("none are preferred")
+  end
+end

--- a/spec/unit/validation/rules/related_concept_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_rule_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::RelatedConceptRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_types) { Glossarist::GlossaryDefinition::RELATED_CONCEPT_TYPES }
+
+  def make_related(type:, ref_id: "1.1")
+    rc = Glossarist::RelatedConcept.new(type: type, content: ref_id)
+    rc.ref = Glossarist::ConceptRef.new(id: ref_id)
+    rc
+  end
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-200")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "is not applicable when the concept has no related entries" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "returns no issues for every valid relationship type" do
+    valid_types.first(3).each do |type|
+      mc = make_managed_concept(id: "x")
+      mc.related = [make_related(type: type)]
+      cc = make_concept_context(mc, collection_context: dataset_context)
+      expect(rule.check(cc)).to be_empty, "expected no issues for #{type}"
+    end
+  end
+
+  it "flags a related concept with an invalid type" do
+    mc = make_managed_concept(id: "x")
+    mc.related = [make_related(type: "not_a_relationship")]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("not_a_relationship")
+    expect(issues.first.suggestion).to include(valid_types.first)
+  end
+end

--- a/spec/unit/validation/rules/source_type_rule_spec.rb
+++ b/spec/unit/validation/rules/source_type_rule_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::SourceEnumRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+  let(:valid_types) { Glossarist::GlossaryDefinition::CONCEPT_SOURCE_TYPES }
+  let(:valid_statuses) { Glossarist::GlossaryDefinition::CONCEPT_SOURCE_STATUSES }
+
+  def make_source(type: "authoritative", status: "identical")
+    Glossarist::ConceptSource.new(
+      type: type,
+      status: status,
+      origin: Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(source: "ISO")),
+    )
+  end
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-202")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues for a source with valid type and status" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [make_source]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a source with an invalid type" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [make_source(type: "invented")]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.code).to eq("GLS-202")
+    expect(issues.first.message).to include("invalid type")
+    expect(issues.first.suggestion).to include(valid_types.first)
+  end
+
+  it "flags a source with an invalid status (separate GLS-203 code)" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.sources = [make_source(status: "wrong")]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.code).to eq("GLS-203")
+    expect(issues.first.message).to include("invalid status")
+    expect(issues.first.suggestion).to include(valid_statuses.first)
+  end
+end

--- a/spec/unit/validation/rules/terms_presence_rule_spec.rb
+++ b/spec/unit/validation/rules/terms_presence_rule_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::TermsPresenceRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-005")
+    expect(rule.category).to eq(:structure)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "returns no issues when every localization has at least one term" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "is not applicable when the concept has no localizations" do
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "flags a localization with no terms" do
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = []
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                                  file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("at least 1 term")
+    expect(issues.first.location).to include("eng")
+  end
+end


### PR DESCRIPTION
## Summary

Second batch of focused validation rule specs. Adds 10 more rule specs, covering schema, quality, references, structure, integrity, and localization rule families that exercise richer model state. Closes 10 of the 17 spec-coverage gaps remaining after batch 1 (#198).

Uses the same `ValidationRuleSpecHelper` from batch 1 — real `ConceptContext` / `DatasetContext` instances, no doubles.

### Rules covered (10)

| Code | Rule | What it tests |
|------|------|---------------|
| GLS-005 | `TermsPresenceRule` | every localization has ≥1 term |
| GLS-012 | `LanguageListRule` | declared vs actual language set diff |
| GLS-013 | `LanguageCoverageRule` | every declared language is present per concept |
| GLS-100 | `ConceptMentionRule` | `{{id}}` inline mentions resolve against `concept_ids` |
| GLS-103 | `ImageReferenceRule` | `image::path[]` resolves against asset index |
| GLS-200 | `RelatedConceptRule` | valid `RELATED_CONCEPT_TYPES` enum |
| GLS-202/203 | `SourceEnumRule` | valid source type + status enums (separate codes per violation) |
| GLS-301 | `PreferredTermRule` | at least one term has `normative_status: preferred` |
| GLS-304 | `CitationCompletenessRule` | `origin.ref` has source or id |
| GLS-306 | `AuthoritativeSourceRule` | at least one `type: authoritative` source |

### Highlights

- **LanguageCoverageRule + LanguageListRule** write a real `register.yaml` into a tmpdir, then exercise the `DatasetContext` lazy `load_register_data → declared_languages` path. Confirms the `RegisterData.languages` accessor (which replaced the hand-rolled `#[]` removed in PR #196) works end-to-end.
- **ConceptMentionRule** spec seeds both referrer and mentioned concepts before building `ConceptContext`, since `concept_ids` is memoized on `DatasetContext`.

## Test plan

- [x] All 10 new specs pass individually
- [x] `bundle exec rspec` full suite — 1622 examples, 0 failures (up from 1578; +44 new examples)
- [x] `bundle exec rubocop` — clean

## Remaining gaps (batch 3, deferred)

7 rules still lack focused specs. They need richer fixtures:
- **GCR-context rules** (`ConceptCountRule`, `ConceptUriRule`, `FilenameIdRule`) — need a `GcrContext` test factory with a real ZIP archive
- **Orphaned family** (`OrphanedBibliographyRule`, `OrphanedImagesRule`, `OrphanedL10nFilesRule`) — need `bibliography.yaml`, `images/` dir, `localized_concept/` dir fixtures
- **`BibliographyYamlRule`** — needs a fixture bibliography.yaml with shape violations

Batch 3 will tackle these.
