### PR TITLE
test(validation): specs for orphaned-* rules + fix OrphanedImagesRule path mismatch (batch 3)

### DIFF
--- a/lib/glossarist/validation/rules/orphaned_images_rule.rb
+++ b/lib/glossarist/validation/rules/orphaned_images_rule.rb
@@ -15,7 +15,7 @@ module Glossarist
 
         def check(context)
           extractor = ReferenceExtractor.new
-          referenced_paths = Set.new
+          referenced_basenames = Set.new
 
           context.concepts.each do |concept|
             concept.localizations.each do |l10n|
@@ -23,19 +23,21 @@ module Glossarist
                 next unless text
 
                 extractor.extract_from_text(text).each do |ref|
-                  referenced_paths.add(ref.path) if ref.is_a?(AssetReference)
+                  if ref.is_a?(AssetReference)
+                    referenced_basenames.add(File.basename(ref.path))
+                  end
                 end
               end
             end
 
             extractor.extract_asset_refs_from_concept(concept).each do |ref|
-              referenced_paths.add(ref.path)
+              referenced_basenames.add(File.basename(ref.path))
             end
           end
 
           issues = []
           context.asset_index.each_path do |path|
-            next if referenced_paths.include?(path)
+            next if referenced_basenames.include?(File.basename(path))
 
             issues << issue(
               "Orphaned image: #{path} (not referenced by any concept)",

--- a/spec/unit/validation/rules/orphaned_bibliography_rule_spec.rb
+++ b/spec/unit/validation/rules/orphaned_bibliography_rule_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::OrphanedBibliographyRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-020")
+    expect(rule.category).to eq(:references)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when the bibliography index is empty" do
+    expect(rule).not_to be_applicable(dataset_context)
+  end
+
+  context "with a bibliography.yaml and a concept that does not cite" do
+    let(:dataset_context) do
+      File.write(File.join(tmpdir, "bibliography.yaml"), <<~YAML, encoding: "utf-8")
+        ---
+        bibliography:
+        - id: ISO_9000
+          reference: ISO 9000
+      YAML
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "x", langs: {
+                                            eng: { definition: [{ "content" => "a definition with no xrefs" }] },
+                                          }))
+      ds
+    end
+
+    it "flags the bibliography entry as orphaned" do
+      issues = rule.check(dataset_context)
+      # The rule currently flags every entry when none are referenced
+      # (the any? check in the loop short-circuits per entry).
+      expect(issues).not_to be_empty
+      expect(issues.first.message).to include("ISO 9000")
+    end
+  end
+
+  context "with a bibliography entry that a concept cites via <<anchor>>" do
+    let(:dataset_context) do
+      File.write(File.join(tmpdir, "bibliography.yaml"), <<~YAML, encoding: "utf-8")
+        ---
+        bibliography:
+        - id: ISO_9000
+          reference: ISO 9000
+      YAML
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "x", langs: {
+                                            eng: { definition: [{ "content" => "See <<ISO_9000>> for context." }] },
+                                          }))
+      ds
+    end
+
+    it "returns no issues when the entry is cited" do
+      issues = rule.check(dataset_context)
+      expect(issues).to be_empty
+    end
+  end
+end

--- a/spec/unit/validation/rules/orphaned_images_rule_spec.rb
+++ b/spec/unit/validation/rules/orphaned_images_rule_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::OrphanedImagesRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-021")
+    expect(rule.category).to eq(:references)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when the asset index is empty" do
+    expect(rule).not_to be_applicable(dataset_context)
+  end
+
+  context "with an images/ directory and a concept" do
+    before do
+      images_dir = File.join(tmpdir, "images")
+      FileUtils.mkdir_p(images_dir)
+      File.write(File.join(images_dir, "referenced.png"), "png",
+                 encoding: "utf-8")
+      File.write(File.join(images_dir, "orphaned.png"), "png",
+                 encoding: "utf-8")
+      # Rebuild dataset_context so asset_index picks up the new files.
+      @dataset_context = make_dataset_context(tmpdir)
+      referrer = make_managed_concept(id: "x", langs: {
+                                        eng: { definition: [{ "content" => "image::referenced.png[]" }] },
+                                      })
+      @dataset_context.add_concept(referrer)
+    end
+
+    let(:dataset_context) { @dataset_context }
+
+    it "flags the image not referenced by any concept" do
+      issues = rule.check(dataset_context)
+      orphaned = issues.map(&:message).join("\n")
+      expect(orphaned).to include("orphaned.png")
+      expect(orphaned).not_to include("referenced.png")
+    end
+  end
+end

--- a/spec/unit/validation/rules/orphaned_l10n_files_rule_spec.rb
+++ b/spec/unit/validation/rules/orphaned_l10n_files_rule_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::OrphanedL10nFilesRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-019")
+    expect(rule.category).to eq(:integrity)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when the localization_index is empty" do
+    ds = make_dataset_context(tmpdir)
+    expect(rule).not_to be_applicable(ds)
+  end
+
+  context "with two l10n files but only one referenced" do
+    let(:dataset_context) do
+      lc_dir = File.join(tmpdir, "concepts", "localized_concept")
+      FileUtils.mkdir_p(lc_dir)
+      File.write(File.join(lc_dir, "lc-referenced.yaml"), "---\ndata: {}\n",
+                 encoding: "utf-8")
+      File.write(File.join(lc_dir, "lc-orphaned.yaml"), "---\ndata: {}\n",
+                 encoding: "utf-8")
+      ds = make_dataset_context(tmpdir)
+      mc = make_managed_concept(id: "x")
+      mc.data.localized_concepts = { "eng" => "lc-referenced" }
+      ds.add_concept(mc)
+      ds
+    end
+
+    it "flags the unreferenced l10n file" do
+      issues = rule.check(dataset_context)
+      expect(issues.length).to eq(1)
+      expect(issues.first.message).to include("lc-orphaned.yaml")
+    end
+  end
+
+  context "when every l10n file is referenced" do
+    let(:dataset_context) do
+      lc_dir = File.join(tmpdir, "concepts", "localized_concept")
+      FileUtils.mkdir_p(lc_dir)
+      File.write(File.join(lc_dir, "lc-1.yaml"), "---\ndata: {}\n",
+                 encoding: "utf-8")
+      ds = make_dataset_context(tmpdir)
+      mc = make_managed_concept(id: "x")
+      mc.data.localized_concepts = { "eng" => "lc-1" }
+      ds.add_concept(mc)
+      ds
+    end
+
+    it "returns no issues" do
+      expect(rule.check(dataset_context)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Third batch of validation rule specs. Covers the orphaned-* detection family and fixes a real bug found while writing the OrphanedImagesRule spec.

### Bug fix: `OrphanedImagesRule` path mismatch

The spec exposed a real defect: reference paths from inline `image::foo.png[]` mentions come out of `ReferenceExtractor` as `"foo.png"`, but `AssetIndex` stores the same file as `"images/foo.png"` (the indexer walks the `images/` subdir and registers paths relative to the dataset root). The rule's `referenced_paths.include?(path)` check never matched, so **every** image was being flagged as orphaned — even ones that were referenced.

Fix: compare by basename. Both forms reduce to the same basename, which is unique within `AssetIndex`'s `images/<file>` storage form. No performance regression — still O(N+M) with Set lookups.

### Rules covered (3)

| Code | Rule | What it tests |
|------|------|---------------|
| GLS-019 | `OrphanedL10nFilesRule` | files under `concepts/localized_concept/` that no `ManagedConcept#localized_concepts` map references |
| GLS-020 | `OrphanedBibliographyRule` | entries in `bibliography.yaml` that no concept cites via `<<anchor>>` |
| GLS-021 | `OrphanedImagesRule` | files under `images/` that no concept references via `image::path[]` or `NonVerbRep` (bug-fixed) |

## Test plan

- [x] All 3 new specs pass individually
- [x] `bundle exec rspec` full suite — 1633 examples, 0 failures (up from 1622; +11 new examples)
- [x] `bundle exec rubocop` — clean

## Remaining gaps (batch 4, deferred)

4 GCR-context rules still lack focused specs:
- `BibliographyYamlRule` — needs a real `.gcr` zip fixture with malformed bibliography.yaml
- `ConceptCountRule` — needs `context.metadata` with `concept_count` (only GcrContext supplies metadata)
- `ConceptUriRule` — needs GCR context with metadata.uri_prefix
- `FilenameIdRule` — needs GCR context with `concepts/{id}.yaml` entries

These need a `GcrContext` test factory that builds a real ZIP archive in tmpdir. Batch 4 will tackle them.
