### PR TITLE
test(validation): add focused specs for the 4 GCR-context rules (batch 4)

### DIFF
--- a/spec/support/validation_rule_spec_helper.rb
+++ b/spec/support/validation_rule_spec_helper.rb
@@ -48,6 +48,24 @@ module ValidationRuleSpecHelper
       collection_context: collection_context,
     )
   end
+
+  # Build a minimal .gcr ZIP archive in tmpdir containing the named files.
+  # files is a hash of { "path/in/zip" => "content" }.
+  # Returns the path to the created zip.
+  def make_gcr_zip(tmpdir, files:, name: "test.gcr")
+    require "zip"
+    zip_path = File.join(tmpdir, name)
+    Zip::File.open(zip_path, create: true) do |zf|
+      files.each do |path, content|
+        zf.get_output_stream(path) { |f| f.write(content) }
+      end
+    end
+    zip_path
+  end
+
+  def make_gcr_context(zip_path)
+    Glossarist::Validation::Rules::GcrContext.new(zip_path)
+  end
 end
 
 RSpec.configure do |config|

--- a/spec/unit/validation/rules/bibliography_yaml_rule_spec.rb
+++ b/spec/unit/validation/rules/bibliography_yaml_rule_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::BibliographyYamlRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-020-YAML")
+    expect(rule.category).to eq(:structure)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable on a non-GCR context" do
+    ds = make_dataset_context(tmpdir)
+    expect(rule).not_to be_applicable(ds)
+  end
+
+  it "returns no issues when bibliography.yaml parses cleanly" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "bibliography.yaml" => <<~YAML,
+                           ---
+                           bibliography:
+                           - id: ISO_9000
+                             reference: ISO 9000
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    expect(rule.check(gcr)).to be_empty
+  end
+
+  it "returns no issues when bibliography.yaml is absent" do
+    zip = make_gcr_zip(tmpdir, files: { "metadata.yaml" => "---\n" })
+    gcr = make_gcr_context(zip)
+    expect(rule.check(gcr)).to be_empty
+  end
+
+  it "flags malformed YAML in bibliography.yaml" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "bibliography.yaml" => "this: is: not: valid: yaml: [unclosed",
+                       })
+    gcr = make_gcr_context(zip)
+    issues = rule.check(gcr)
+    expect(issues.length).to eq(1)
+    expect(issues.first.code).to eq("GLS-020-YAML")
+    expect(issues.first.message).to include("invalid YAML")
+  end
+end

--- a/spec/unit/validation/rules/concept_count_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_count_rule_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptCountRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-011")
+    expect(rule.category).to eq(:integrity)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when metadata has no concept_count" do
+    zip = make_gcr_zip(tmpdir, files: { "metadata.yaml" => "---\nshortname: x\n" })
+    gcr = make_gcr_context(zip)
+    expect(rule).not_to be_applicable(gcr)
+  end
+
+  it "returns no issues when concept_count matches the actual count" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "metadata.yaml" => <<~YAML,
+                           ---
+                           shortname: x
+                           concept_count: 2
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    gcr.add_concept(make_managed_concept(id: "1"))
+    gcr.add_concept(make_managed_concept(id: "2"))
+    expect(rule.check(gcr)).to be_empty
+  end
+
+  it "flags a mismatch between declared and actual concept_count" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "metadata.yaml" => <<~YAML,
+                           ---
+                           shortname: x
+                           concept_count: 5
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    gcr.add_concept(make_managed_concept(id: "1"))
+    issues = rule.check(gcr)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("5")
+    expect(issues.first.message).to include("1 concept")
+  end
+end

--- a/spec/unit/validation/rules/concept_uri_rule_spec.rb
+++ b/spec/unit/validation/rules/concept_uri_rule_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::ConceptUriRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-014")
+    expect(rule.category).to eq(:structure)
+    expect(rule.severity).to eq("warning")
+    expect(rule.scope).to eq(:collection)
+  end
+
+  it "is not applicable when metadata has no uri_prefix or concept_uri_template" do
+    # The rule's applicable? requires context.metadata to load successfully.
+    # GcrMetadata requires certain fields, so give it a minimal valid form
+    # that lacks uri_prefix/concept_uri_template — the rule should still
+    # apply and flag the missing fields (covered in the next example).
+    zip = make_gcr_zip(tmpdir, files: {
+                         "metadata.yaml" => <<~YAML,
+                           ---
+                           shortname: x
+                           concept_count: 1
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    expect(rule).to be_applicable(gcr)
+  end
+
+  it "returns no issues when metadata declares a uri_prefix" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "metadata.yaml" => <<~YAML,
+                           ---
+                           shortname: x
+                           uri_prefix: https://example.org/concepts/
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    expect(rule.check(gcr)).to be_empty
+  end
+
+  it "flags missing uri_prefix and concept_uri_template" do
+    zip = make_gcr_zip(tmpdir, files: {
+                         "metadata.yaml" => <<~YAML,
+                           ---
+                           shortname: x
+                           concept_count: 1
+                         YAML
+                       })
+    gcr = make_gcr_context(zip)
+    issues = rule.check(gcr)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("URI prefix")
+    expect(issues.first.suggestion).to include("uri_prefix")
+  end
+end

--- a/spec/unit/validation/rules/filename_id_rule_spec.rb
+++ b/spec/unit/validation/rules/filename_id_rule_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::FilenameIdRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-015")
+    expect(rule.category).to eq(:integrity)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "is not applicable on a non-GCR context" do
+    ds = make_dataset_context(tmpdir)
+    mc = make_managed_concept(id: "x")
+    cc = make_concept_context(mc, collection_context: ds)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "returns no issues when the filename matches the concept id" do
+    zip = make_gcr_zip(tmpdir, files: { "metadata.yaml" => "---\n" })
+    gcr = make_gcr_context(zip)
+    mc = make_managed_concept(id: "1.1")
+    cc = make_concept_context(mc, collection_context: gcr,
+                                  file_name: "concepts/1.1.yaml")
+    expect(rule.check(cc)).to be_empty
+  end
+
+  it "flags a filename that does not match the concept id" do
+    zip = make_gcr_zip(tmpdir, files: { "metadata.yaml" => "---\n" })
+    gcr = make_gcr_context(zip)
+    mc = make_managed_concept(id: "1.1")
+    cc = make_concept_context(mc, collection_context: gcr,
+                                  file_name: "concepts/something-else.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.message).to include("something-else")
+    expect(issues.first.message).to include("1.1")
+  end
+end


### PR DESCRIPTION
## Summary

Final batch of validation rule specs. Closes the last 4 spec-coverage gaps — the GCR-context rules that need a real `.gcr` ZIP archive fixture. **With this batch, all 44 validation rules have dedicated focused specs.**

The original audit in PR #196 called out "23 of 44 rules lack focused specs." Batches 1 (#198), 2 (#199), 3 (#200), and this PR close that gap completely.

### Helper additions

`spec/support/validation_rule_spec_helper.rb`:
- `make_gcr_zip(tmpdir, files:, name:)` — builds a minimal `.gcr` ZIP archive in tmpdir. `files` is a hash of `{ "path/in/zip" => "content" }`.
- `make_gcr_context(zip_path)` — wraps the zip in a `GcrContext`.

### Rules covered (4)

| Code | Rule | What it tests |
|------|------|---------------|
| GLS-011 | `ConceptCountRule` | `metadata.concept_count` vs actual concept count |
| GLS-014 | `ConceptUriRule` | `metadata.uri_prefix` or `concept_uri_template` declared |
| GLS-015 | `FilenameIdRule` | `concepts/{id}.yaml` filename matches `concept.data.id` |
| GLS-020-YAML | `BibliographyYamlRule` | `bibliography.yaml` parses as valid YAML; absent is OK |

## Test plan

- [x] All 4 new specs pass individually
- [x] `bundle exec rspec` full suite — 1650 examples, 0 failures (up from 1633; +17 new examples)
- [x] `bundle exec rubocop` — clean
- [x] All 44 validation rules now have dedicated `_spec.rb` files (`ls lib/glossarist/validation/rules/*_rule.rb | wc -l` == `ls spec/unit/validation/rules/*_rule_spec.rb | wc -l` == 44)

## Series summary

| Batch | PR | Rules covered | Cumulative |
|-------|-----|---------------|------------|
| 1 | #198 | 14 (concept-scoped rule families) | 14/44 |
| 2 | #199 | 10 (schema, quality, references, integrity) | 24/44 |
| 3 | #200 | 3 (orphaned-* + path bug fix) | 27/44 |
| 4 | this PR | 4 (GCR-context rules) | **44/44** |

Net: +108 spec examples added across the series. One real bug fixed (OrphanedImagesRule path mismatch, batch 3). Helper introduced (`ValidationRuleSpecHelper`) makes future rule specs mechanical to write — real model instances throughout, no doubles.
