### PR TITLE
test(validation): replace doubles with real instances in 5 rule specs

### DIFF
--- a/spec/unit/validation/rules/domain_ref_rule_spec.rb
+++ b/spec/unit/validation/rules/domain_ref_rule_spec.rb
@@ -5,10 +5,20 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::DomainRefRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
   def make_context(concept)
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
+      concept, file_name: "test.yaml", collection_context: dataset_context
     )
+  end
+
+  def make_concept_with_domain(domain_ref)
+    mc = make_managed_concept(id: "x")
+    mc.data.domains = [domain_ref]
+    mc
   end
 
   describe "#code" do
@@ -18,31 +28,19 @@ RSpec.describe Glossarist::Validation::Rules::DomainRefRule do
   describe "#check" do
     it "passes for domain with concept_id" do
       domain = Glossarist::ConceptReference.new(concept_id: "section-3-1")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      concept = make_concept_with_domain(domain)
+      expect(rule.check(make_context(concept))).to be_empty
     end
 
     it "passes for domain with urn" do
       domain = Glossarist::ConceptReference.new(urn: "urn:iso:std:iso:ts:14812")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      concept = make_concept_with_domain(domain)
+      expect(rule.check(make_context(concept))).to be_empty
     end
 
     it "flags domain with neither concept_id nor urn" do
       domain = Glossarist::ConceptReference.new(source: "ISO")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
+      concept = make_concept_with_domain(domain)
       issues = rule.check(make_context(concept))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("neither concept_id nor urn")

--- a/spec/unit/validation/rules/domain_target_rule_spec.rb
+++ b/spec/unit/validation/rules/domain_target_rule_spec.rb
@@ -5,11 +5,23 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::DomainTargetRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def make_concept_with_domain(domain_ref)
+    mc = make_managed_concept(id: "x")
+    mc.data.domains = [domain_ref]
+    mc
+  end
+
   def make_context(concept, concept_ids: Set.new)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext)
-    allow(cc).to receive(:concept_ids).and_return(concept_ids)
+    ds = make_dataset_context(tmpdir)
+    # Seed concept_ids via add_concept; the set is memoized.
+    concept_ids.each do |id|
+      ds.add_concept(make_managed_concept(id: id))
+    end
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: cc
+      concept, file_name: "test.yaml", collection_context: ds
     )
   end
 
@@ -20,23 +32,16 @@ RSpec.describe Glossarist::Validation::Rules::DomainTargetRule do
   describe "#check" do
     it "passes for local domain ref that exists" do
       domain = Glossarist::ConceptReference.new(concept_id: "section-3-1")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept,
-                                       concept_ids: Set.new(["section-3-1"])))
-      expect(issues).to be_empty
+      concept = make_concept_with_domain(domain)
+      cc = make_context(concept, concept_ids: Set.new(["section-3-1"]))
+      expect(rule.check(cc)).to be_empty
     end
 
     it "flags local domain ref not in dataset" do
       domain = Glossarist::ConceptReference.new(concept_id: "nonexistent")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept,
-                                       concept_ids: Set.new(["section-3-1"])))
+      concept = make_concept_with_domain(domain)
+      cc = make_context(concept, concept_ids: Set.new(["section-3-1"]))
+      issues = rule.check(cc)
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("not in dataset")
     end
@@ -46,21 +51,16 @@ RSpec.describe Glossarist::Validation::Rules::DomainTargetRule do
         concept_id: "section-3-1",
         source: "urn:iso:std:iso:ts:14812",
       )
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept, concept_ids: Set.new))
-      expect(issues).to be_empty
+      concept = make_concept_with_domain(domain)
+      cc = make_context(concept)
+      expect(rule.check(cc)).to be_empty
     end
 
     it "flags invalid URN" do
       domain = Glossarist::ConceptReference.new(urn: "urn:invalid urn!!!")
-      data = instance_double(Glossarist::ManagedConceptData, domains: [domain])
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(data).to receive(:domains).and_return([domain])
-
-      issues = rule.check(make_context(concept, concept_ids: Set.new))
+      concept = make_concept_with_domain(domain)
+      cc = make_context(concept)
+      issues = rule.check(cc)
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("invalid URN")
     end

--- a/spec/unit/validation/rules/localization_consistency_rule_spec.rb
+++ b/spec/unit/validation/rules/localization_consistency_rule_spec.rb
@@ -5,17 +5,14 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::LocalizationConsistencyRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
   def make_context(concept)
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
+      concept, file_name: "test.yaml", collection_context: dataset_context
     )
-  end
-
-  def make_l10n(lang, uuid)
-    l10n = instance_double(Glossarist::LocalizedConcept)
-    allow(l10n).to receive(:language_code).and_return(lang)
-    allow(l10n).to receive(:uuid).and_return(uuid)
-    l10n
   end
 
   describe "#code" do
@@ -24,49 +21,36 @@ RSpec.describe Glossarist::Validation::Rules::LocalizationConsistencyRule do
 
   describe "#check" do
     it "passes when map and localizations are consistent" do
-      l10n = make_l10n("eng", "abc-123")
-      data = instance_double(Glossarist::ManagedConceptData,
-                             localized_concepts: { "eng" => "abc-123" })
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(concept).to receive(:localizations).and_return([l10n])
-
-      issues = rule.check(make_context(concept))
+      mc = make_managed_concept(id: "x", langs: { eng: {} })
+      mc.data.localized_concepts = { "eng" => mc.localization("eng").uuid }
+      issues = rule.check(make_context(mc))
       expect(issues).to be_empty
     end
 
     it "flags map entry with no loaded localization" do
-      data = instance_double(Glossarist::ManagedConceptData,
-                             localized_concepts: { "eng" => "abc-123",
-                                                   "fra" => "def-456" })
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      l10n = make_l10n("eng", "abc-123")
-      allow(concept).to receive(:localizations).and_return([l10n])
-
-      issues = rule.check(make_context(concept))
+      mc = make_managed_concept(id: "x", langs: { eng: {} })
+      mc.data.localized_concepts = {
+        "eng" => mc.localization("eng").uuid,
+        "fra" => "missing-uuid",
+      }
+      issues = rule.check(make_context(mc))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("fra")
     end
 
     it "flags loaded localization not in map" do
-      l10n = make_l10n("eng", "abc-123")
-      data = instance_double(Glossarist::ManagedConceptData,
-                             localized_concepts: {})
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(concept).to receive(:localizations).and_return([l10n])
-
-      issues = rule.check(make_context(concept))
+      mc = make_managed_concept(id: "x", langs: { eng: {} })
+      # map is empty by default; the loaded eng localization has no entry.
+      mc.data.localized_concepts = {}
+      issues = rule.check(make_context(mc))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("not in localized_concepts map")
     end
 
     it "flags UUID mismatch between map and localization" do
-      l10n = make_l10n("eng", "wrong-uuid")
-      data = instance_double(Glossarist::ManagedConceptData,
-                             localized_concepts: { "eng" => "abc-123" })
-      concept = instance_double(Glossarist::ManagedConcept, data: data)
-      allow(concept).to receive(:localizations).and_return([l10n])
-
-      issues = rule.check(make_context(concept))
+      mc = make_managed_concept(id: "x", langs: { eng: {} })
+      mc.data.localized_concepts = { "eng" => "different-uuid" }
+      issues = rule.check(make_context(mc))
       expect(issues.any? { |i| i.message.include?("UUID mismatch") }).to be true
     end
   end

--- a/spec/unit/validation/rules/related_concept_target_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_target_rule_spec.rb
@@ -5,12 +5,22 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::RelatedConceptTargetRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   def make_context(concept, concept_ids: Set.new)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext)
-    allow(cc).to receive(:concept_ids).and_return(concept_ids)
+    ds = make_dataset_context(tmpdir)
+    concept_ids.each { |id| ds.add_concept(make_managed_concept(id: id)) }
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: cc
+      concept, file_name: "test.yaml", collection_context: ds
     )
+  end
+
+  def make_concept_with_related(ref:)
+    mc = make_managed_concept(id: "x")
+    mc.related = [Glossarist::RelatedConcept.new(content: "test",
+                                                 type: "broader", ref: ref)]
+    mc
   end
 
   describe "#code" do
@@ -20,23 +30,16 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptTargetRule do
   describe "#check" do
     it "passes when related concept target exists in dataset" do
       ref = Glossarist::ConceptRef.new(id: "3.1.3.9")
-      related = [Glossarist::RelatedConcept.new(content: "test",
-                                                type: "broader", ref: ref)]
-      concept = instance_double(Glossarist::ManagedConcept, related: related)
-
-      issues = rule.check(make_context(concept,
-                                       concept_ids: Set.new(["3.1.3.9"])))
-      expect(issues).to be_empty
+      concept = make_concept_with_related(ref: ref)
+      cc = make_context(concept, concept_ids: Set.new(["3.1.3.9"]))
+      expect(rule.check(cc)).to be_empty
     end
 
     it "flags local ref to non-existent concept" do
       ref = Glossarist::ConceptRef.new(id: "9.9.9.9")
-      related = [Glossarist::RelatedConcept.new(content: "test",
-                                                type: "broader", ref: ref)]
-      concept = instance_double(Glossarist::ManagedConcept, related: related)
-
-      issues = rule.check(make_context(concept,
-                                       concept_ids: Set.new(["3.1.3.9"])))
+      concept = make_concept_with_related(ref: ref)
+      cc = make_context(concept, concept_ids: Set.new(["3.1.3.9"]))
+      issues = rule.check(cc)
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("not in the dataset")
     end
@@ -44,21 +47,16 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptTargetRule do
     it "passes for external ref with valid URN" do
       ref = Glossarist::ConceptRef.new(source: "urn:iso:std:iso:ts:14812",
                                        id: "section-3-1")
-      related = [Glossarist::RelatedConcept.new(content: "test",
-                                                type: "broader", ref: ref)]
-      concept = instance_double(Glossarist::ManagedConcept, related: related)
-
-      issues = rule.check(make_context(concept, concept_ids: Set.new))
-      expect(issues).to be_empty
+      concept = make_concept_with_related(ref: ref)
+      cc = make_context(concept)
+      expect(rule.check(cc)).to be_empty
     end
 
     it "flags invalid URN format" do
       ref = Glossarist::ConceptRef.new(source: "urn:not a valid urn!!!")
-      related = [Glossarist::RelatedConcept.new(content: "test",
-                                                type: "broader", ref: ref)]
-      concept = instance_double(Glossarist::ManagedConcept, related: related)
-
-      issues = rule.check(make_context(concept, concept_ids: Set.new))
+      concept = make_concept_with_related(ref: ref)
+      cc = make_context(concept)
+      issues = rule.check(cc)
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("invalid URN")
     end

--- a/spec/unit/validation/rules/schema_enum_rules_spec.rb
+++ b/spec/unit/validation/rules/schema_enum_rules_spec.rb
@@ -2,237 +2,91 @@
 
 require "spec_helper"
 
+# Aggregate spec for the schema-enum validation rules. Each rule also has
+# a dedicated _spec.rb with richer coverage (see spec/unit/validation/rules/).
+# This file is kept for the additional edge cases it covers (e.g. symbol
+# designations, date_accepted branching). Uses real model instances via
+# ValidationRuleSpecHelper — no doubles.
+
 RSpec.describe Glossarist::Validation::Rules::DesignationStatusRule do
   subject(:rule) { described_class.new }
 
-  def make_context(terms)
-    l10n = instance_double(Glossarist::LocalizedConcept)
-    allow(l10n).to receive(:language_code).and_return("eng")
-    allow(l10n).to receive_message_chain(:data, :terms).and_return(terms)
-
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return([l10n])
-
-    ctx = instance_double(Glossarist::Validation::Rules::ConceptContext)
-    allow(ctx).to receive(:concept).and_return(concept)
-    allow(ctx).to receive(:file_name).and_return("test.yaml")
-    ctx
-  end
-
-  it "has correct metadata" do
-    expect(rule.code).to eq("GLS-204")
-    expect(rule.category).to eq(:schema)
-    expect(rule.severity).to eq("error")
-    expect(rule.scope).to eq(:concept)
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
   it "passes for valid normative_status" do
     term = Glossarist::Designation::Expression.new(
       designation: "test", normative_status: "preferred",
     )
-    issues = rule.check(make_context([term]))
-    expect(issues).to be_empty
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [term]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
   end
 
   it "reports invalid normative_status" do
     term = Glossarist::Designation::Expression.new(
       designation: "test", normative_status: "invalid_status",
     )
-    issues = rule.check(make_context([term]))
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [term]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
     expect(issues.size).to eq(1)
     expect(issues.first.message).to include("invalid normative_status")
   end
 
   it "skips nil normative_status" do
     term = Glossarist::Designation::Expression.new(designation: "test")
-    issues = rule.check(make_context([term]))
-    expect(issues).to be_empty
-  end
-end
-
-RSpec.describe Glossarist::Validation::Rules::DateTypeRule do
-  subject(:rule) { described_class.new }
-
-  def make_context(dates, date_accepted = nil)
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:dates).and_return(dates)
-    allow(concept).to receive(:date_accepted).and_return(date_accepted)
-
-    ctx = instance_double(Glossarist::Validation::Rules::ConceptContext)
-    allow(ctx).to receive(:concept).and_return(concept)
-    allow(ctx).to receive(:file_name).and_return("test.yaml")
-    ctx
-  end
-
-  it "has correct metadata" do
-    expect(rule.code).to eq("GLS-205")
-    expect(rule.category).to eq(:schema)
-    expect(rule.severity).to eq("warning")
-    expect(rule.scope).to eq(:concept)
-  end
-
-  it "passes for valid date types" do
-    date = Glossarist::ConceptDate.new(date: "2024-01-01", type: "accepted")
-    issues = rule.check(make_context([date]))
-    expect(issues).to be_empty
-  end
-
-  it "reports invalid date type" do
-    date = Glossarist::ConceptDate.new(date: "2024-01-01", type: "invalid")
-    issues = rule.check(make_context([date]))
-    expect(issues.size).to eq(1)
-    expect(issues.first.message).to include("invalid type")
-  end
-
-  it "skips dates with no type" do
-    date = Glossarist::ConceptDate.new(date: "2024-01-01")
-    issues = rule.check(make_context([date]))
-    expect(issues).to be_empty
-  end
-
-  it "checks date_accepted type" do
-    da = Glossarist::ConceptDate.new(date: "2024-01-01", type: "invalid")
-    issues = rule.check(make_context([], da))
-    expect(issues.size).to eq(1)
-  end
-end
-
-RSpec.describe Glossarist::Validation::Rules::LanguageCodeFormatRule do
-  subject(:rule) { described_class.new }
-
-  def make_context(lang_codes)
-    l10ns = lang_codes.map do |code|
-      l10n = instance_double(Glossarist::LocalizedConcept)
-      allow(l10n).to receive(:language_code).and_return(code)
-      l10n
-    end
-
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return(l10ns)
-
-    ctx = instance_double(Glossarist::Validation::Rules::ConceptContext)
-    allow(ctx).to receive(:concept).and_return(concept)
-    allow(ctx).to receive(:file_name).and_return("test.yaml")
-    ctx
-  end
-
-  it "has correct metadata" do
-    expect(rule.code).to eq("GLS-206")
-    expect(rule.category).to eq(:schema)
-    expect(rule.severity).to eq("error")
-    expect(rule.scope).to eq(:concept)
-  end
-
-  it "passes for valid 3-letter codes" do
-    issues = rule.check(make_context(["eng", "fra", "deu"]))
-    expect(issues).to be_empty
-  end
-
-  it "reports invalid language code" do
-    issues = rule.check(make_context(["en"]))
-    expect(issues.size).to eq(1)
-    expect(issues.first.message).to include("not a valid ISO 639-3 code")
-  end
-
-  it "reports uppercase language code" do
-    issues = rule.check(make_context(["ENG"]))
-    expect(issues.size).to eq(1)
-  end
-
-  it "skips nil language codes" do
-    issues = rule.check(make_context([nil]))
-    expect(issues).to be_empty
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [term]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
   end
 end
 
 RSpec.describe Glossarist::Validation::Rules::DesignationTypeRule do
   subject(:rule) { described_class.new }
 
-  def make_context(terms)
-    l10n = instance_double(Glossarist::LocalizedConcept)
-    allow(l10n).to receive(:language_code).and_return("eng")
-    allow(l10n).to receive_message_chain(:data, :terms).and_return(terms)
-
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return([l10n])
-
-    ctx = instance_double(Glossarist::Validation::Rules::ConceptContext)
-    allow(ctx).to receive(:concept).and_return(concept)
-    allow(ctx).to receive(:file_name).and_return("test.yaml")
-    ctx
-  end
-
-  it "has correct metadata" do
-    expect(rule.code).to eq("GLS-207")
-    expect(rule.category).to eq(:schema)
-    expect(rule.severity).to eq("error")
-    expect(rule.scope).to eq(:concept)
-  end
-
-  it "passes for valid designation types" do
-    term = Glossarist::Designation::Expression.new(designation: "test")
-    issues = rule.check(make_context([term]))
-    expect(issues).to be_empty
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
   it "reports unknown designation type from model" do
     term = Glossarist::Designation::Base.new(type: "unknown_type",
                                              designation: "test")
-    issues = rule.check(make_context([term]))
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [term]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
     expect(issues.size).to eq(1)
     expect(issues.first.message).to include("unknown designation type")
   end
 
   it "passes for symbol designation" do
     term = Glossarist::Designation::Symbol.new(designation: "α")
-    issues = rule.check(make_context([term]))
-    expect(issues).to be_empty
+    mc = make_managed_concept(id: "x", langs: { eng: {} })
+    mc.localization("eng").data.terms = [term]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule.check(cc)).to be_empty
   end
 end
 
 RSpec.describe Glossarist::Validation::Rules::DateValidityRule do
   subject(:rule) { described_class.new }
 
-  def make_context(dates, date_accepted = nil)
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:dates).and_return(dates)
-    allow(concept).to receive(:date_accepted).and_return(date_accepted)
-
-    ctx = instance_double(Glossarist::Validation::Rules::ConceptContext)
-    allow(ctx).to receive(:concept).and_return(concept)
-    allow(ctx).to receive(:file_name).and_return("test.yaml")
-    ctx
-  end
-
-  it "has correct metadata" do
-    expect(rule.code).to eq("GLS-307")
-    expect(rule.category).to eq(:quality)
-    expect(rule.severity).to eq("warning")
-    expect(rule.scope).to eq(:concept)
-  end
-
-  it "passes for valid ISO 8601 dates" do
-    date = Glossarist::ConceptDate.new(date: "2024-01-15", type: "accepted")
-    issues = rule.check(make_context([date]))
-    expect(issues).to be_empty
-  end
-
-  it "reports nil date when type is set" do
-    date = Glossarist::ConceptDate.new(date: "not-a-date", type: "accepted")
-    issues = rule.check(make_context([date]))
-    expect(issues.size).to eq(1)
-    expect(issues.first.message).to include("no date value")
-  end
-
-  it "skips nil dates without type" do
-    date = Glossarist::ConceptDate.new(type: nil)
-    issues = rule.check(make_context([date]))
-    expect(issues).to be_empty
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
   it "checks date_accepted" do
-    da = Glossarist::ConceptDate.new(date: "not-a-date", type: "accepted")
-    issues = rule.check(make_context([], da))
+    mc = make_managed_concept(id: "x")
+    mc.date_accepted = Glossarist::V3::ConceptDate.new(
+      date: "not-a-date", type: "accepted",
+    )
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
     expect(issues.size).to eq(1)
   end
 end


### PR DESCRIPTION
## Summary

Replaces `instance_double` calls with real model instances in 5 validation rule spec files, per the global "NEVER use doubles in specs" rule. **42 doubles eliminated** in this PR.

Uses the `ValidationRuleSpecHelper` introduced in PR #198 (`make_managed_concept`, `make_dataset_context`, `make_concept_context`) — same helper the new rule specs use.

### Files refactored (5)

| File | Doubles before → after | Notes |
|------|------------------------|-------|
| `schema_enum_rules_spec.rb` | 13 → 0 | Also dropped redundant tests now covered by per-rule specs from batch 1; kept the unique edge cases (symbol designations, date_accepted branching) |
| `localization_consistency_rule_spec.rb` | 9 → 0 | Map-vs-loaded consistency tests use real `ManagedConcept` with real `LocalizedConcept` |
| `domain_target_rule_spec.rb` | 9 → 0 | Real `ConceptReference` domain refs and `DatasetContext#concept_ids` |
| `domain_ref_rule_spec.rb` | 6 → 0 | Same pattern as `domain_target_rule` |
| `related_concept_target_rule_spec.rb` | 5 → 0 | Real `RelatedConcept` with real `ConceptRef` |

### Why this matters

The global rule is unambiguous: doubles couple tests to implementation details (which methods get called, in what order) rather than testing actual behavior. When a real model's interface changes, doubles silently pass while real usage breaks. The refactored specs use real instances end-to-end — if the model breaks, the spec breaks.

## Test plan

- [x] All 5 refactored spec files pass individually
- [x] `bundle exec rspec` full suite — 1633 examples, 0 failures (down 17 from 1650: redundant tests in `schema_enum_rules_spec.rb` dropped, those cases are covered by batch 1's per-rule specs)
- [x] `bundle exec rubocop` — clean

## Remaining doubles (~36, deferred)

Smaller files, lower impact:
- `uuid_format_rule_spec.rb` (4)
- `source_urn_format_rule_spec.rb` (4)
- `integrity_rules_spec.rb` (4)
- `quality_rules_spec.rb` (3)
- `locality_completeness_rule_spec.rb` (3)
- `resolution_adapter_spec.rb` (3) — tests HTTP, doubles harder to remove
- `collection_spec.rb` (3)
- `structure_rules_spec.rb` (2)
- `schema_version_rule_spec.rb` (2)
- `schema_rules_spec.rb` (1)

A follow-up batch can tackle these.
