### PR TITLE
test(validation): replace doubles with real instances in 8 more rule specs

### DIFF
--- a/spec/unit/validation/rules/integrity_rules_spec.rb
+++ b/spec/unit/validation/rules/integrity_rules_spec.rb
@@ -2,31 +2,46 @@
 
 require "spec_helper"
 
+# Aggregate spec for integrity-family rules. Each rule also has a dedicated
+# _spec.rb (added in batch 4) with richer coverage using real GCR-context
+# fixtures. This file is retained as an additional smoke test using the
+# ValidationRuleSpecHelper's make_gcr_zip / make_gcr_context factories.
+
 RSpec.describe "Integrity rules" do
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   describe Glossarist::Validation::Rules::ConceptCountRule do
     subject(:rule) { described_class.new }
 
     it "flags when concept_count doesn't match actual count" do
-      metadata = Glossarist::GcrMetadata.new(
-        shortname: "test", version: "1.0.0",
-        concept_count: 5, languages: ["eng"], schema_version: "1"
-      )
-      ctx = instance_double(Glossarist::Validation::Rules::GcrContext,
-                            metadata: metadata, concepts: [double, double], gcr?: true)
-      expect(rule).to be_applicable(ctx)
-      issues = rule.check(ctx)
+      zip = make_gcr_zip(tmpdir, files: {
+                           "metadata.yaml" => <<~YAML,
+                             ---
+                             shortname: test
+                             concept_count: 5
+                           YAML
+                         })
+      gcr = make_gcr_context(zip)
+      gcr.add_concept(make_managed_concept(id: "1"))
+      expect(rule).to be_applicable(gcr)
+      issues = rule.check(gcr)
       expect(issues).not_to be_empty
       expect(issues.first.code).to eq("GLS-011")
     end
 
     it "passes when concept_count matches" do
-      metadata = Glossarist::GcrMetadata.new(
-        shortname: "test", version: "1.0.0",
-        concept_count: 2, languages: ["eng"], schema_version: "1"
-      )
-      ctx = instance_double(Glossarist::Validation::Rules::GcrContext,
-                            metadata: metadata, concepts: [double, double], gcr?: true)
-      expect(rule.check(ctx)).to be_empty
+      zip = make_gcr_zip(tmpdir, files: {
+                           "metadata.yaml" => <<~YAML,
+                             ---
+                             shortname: test
+                             concept_count: 2
+                           YAML
+                         })
+      gcr = make_gcr_context(zip)
+      gcr.add_concept(make_managed_concept(id: "1"))
+      gcr.add_concept(make_managed_concept(id: "2"))
+      expect(rule.check(gcr)).to be_empty
     end
   end
 
@@ -34,27 +49,31 @@ RSpec.describe "Integrity rules" do
     subject(:rule) { described_class.new }
 
     it "warns when no uri_prefix in metadata" do
-      metadata = Glossarist::GcrMetadata.new(
-        shortname: "test", version: "1.0.0",
-        concept_count: 1, languages: ["eng"], schema_version: "1"
-      )
-      ctx = instance_double(Glossarist::Validation::Rules::GcrContext,
-                            metadata: metadata, gcr?: true)
-      expect(rule).to be_applicable(ctx)
-      issues = rule.check(ctx)
+      zip = make_gcr_zip(tmpdir, files: {
+                           "metadata.yaml" => <<~YAML,
+                             ---
+                             shortname: test
+                             concept_count: 1
+                           YAML
+                         })
+      gcr = make_gcr_context(zip)
+      expect(rule).to be_applicable(gcr)
+      issues = rule.check(gcr)
       expect(issues).not_to be_empty
       expect(issues.first.message).to include("no concept URI")
     end
 
     it "passes when uri_prefix is set" do
-      metadata = Glossarist::GcrMetadata.new(
-        shortname: "test", version: "1.0.0",
-        concept_count: 1, languages: ["eng"], schema_version: "1",
-        uri_prefix: "urn:test"
-      )
-      ctx = instance_double(Glossarist::Validation::Rules::GcrContext,
-                            metadata: metadata, gcr?: true)
-      expect(rule.check(ctx)).to be_empty
+      zip = make_gcr_zip(tmpdir, files: {
+                           "metadata.yaml" => <<~YAML,
+                             ---
+                             shortname: test
+                             concept_count: 1
+                             uri_prefix: urn:test
+                           YAML
+                         })
+      gcr = make_gcr_context(zip)
+      expect(rule.check(gcr)).to be_empty
     end
   end
 end

--- a/spec/unit/validation/rules/locality_completeness_rule_spec.rb
+++ b/spec/unit/validation/rules/locality_completeness_rule_spec.rb
@@ -5,20 +5,13 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::LocalityCompletenessRule do
   subject(:rule) { described_class.new }
 
-  def make_concept(sources)
-    l10n = instance_double(Glossarist::LocalizedConcept)
-    allow(l10n).to receive(:data).and_return(
-      instance_double(Glossarist::ConceptData, sources: sources),
-    )
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return([l10n])
-    concept
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
-  def make_context(concept)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
-    )
+  def make_context(sources)
+    mc = make_managed_concept(id: "x", langs: { eng: { sources: sources } })
+    make_concept_context(mc, collection_context: dataset_context)
   end
 
   describe "#code" do
@@ -32,10 +25,7 @@ RSpec.describe Glossarist::Validation::Rules::LocalityCompletenessRule do
       ref = Glossarist::Citation::Ref.new(source: "ISO/TS 14812:2022")
       origin = Glossarist::Citation.new(ref: ref, locality: locality)
       source = Glossarist::ConceptSource.new(origin: origin)
-      concept = make_concept([source])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      expect(rule.check(make_context([source]))).to be_empty
     end
 
     it "flags locality with no type" do
@@ -43,9 +33,7 @@ RSpec.describe Glossarist::Validation::Rules::LocalityCompletenessRule do
       ref = Glossarist::Citation::Ref.new(source: "ISO/TS 14812:2022")
       origin = Glossarist::Citation.new(ref: ref, locality: locality)
       source = Glossarist::ConceptSource.new(origin: origin)
-      concept = make_concept([source])
-
-      issues = rule.check(make_context(concept))
+      issues = rule.check(make_context([source]))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("no type")
     end
@@ -55,9 +43,7 @@ RSpec.describe Glossarist::Validation::Rules::LocalityCompletenessRule do
       ref = Glossarist::Citation::Ref.new(source: "ISO/TS 14812:2022")
       origin = Glossarist::Citation.new(ref: ref, locality: locality)
       source = Glossarist::ConceptSource.new(origin: origin)
-      concept = make_concept([source])
-
-      issues = rule.check(make_context(concept))
+      issues = rule.check(make_context([source]))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("no reference_from")
     end
@@ -66,10 +52,7 @@ RSpec.describe Glossarist::Validation::Rules::LocalityCompletenessRule do
       ref = Glossarist::Citation::Ref.new(source: "ISO/TS 14812:2022")
       origin = Glossarist::Citation.new(ref: ref)
       source = Glossarist::ConceptSource.new(origin: origin)
-      concept = make_concept([source])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      expect(rule.check(make_context([source]))).to be_empty
     end
   end
 end

--- a/spec/unit/validation/rules/quality_rules_spec.rb
+++ b/spec/unit/validation/rules/quality_rules_spec.rb
@@ -2,50 +2,27 @@
 
 require "spec_helper"
 
+# Aggregate spec for quality-family rules. Each rule also has a dedicated
+# _spec.rb with richer coverage; this file is retained as an additional
+# smoke test using real DatasetContext instances (no doubles).
+
 RSpec.describe "Quality rules" do
-  def make_concept(id:, langs: {}, **overrides)
-    mc = Glossarist::ManagedConcept.new(data: { id: id }.merge(overrides))
-    langs.each do |lang, opts|
-      terms = opts[:terms] || [{ "type" => "expression",
-                                 "designation" => "test", "normative_status" => "preferred" }]
-      data = {
-        "language_code" => lang.to_s,
-        "terms" => terms,
-        "definition" => opts[:definition] || [{ "content" => "a definition" }],
-        "entry_status" => opts[:entry_status] || "valid",
-      }
-      data["sources"] = opts[:sources] if opts[:sources]
-      l10n = Glossarist::LocalizedConcept.of_yaml({ "data" => data })
-      mc.add_localization(l10n)
-    end
-    mc
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
 
   def make_context(concept)
-    asset_index = Glossarist::Validation::AssetIndex.new
-    bib_index = Glossarist::Validation::BibliographyIndex.new
-    concept_ids = Set.new([concept.data&.id&.to_s].compact)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                         asset_index: asset_index,
-                         bibliography_index: bib_index,
-                         concept_ids: concept_ids,
-                         declared_languages: %w[eng],
-                         metadata: nil,
-                         gcr?: false)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept,
-      file_name: "concept-#{concept.data.id}.yaml",
-      collection_context: cc,
-    )
+    ds = make_dataset_context(tmpdir)
+    ds.add_concept(concept)
+    make_concept_context(concept, collection_context: ds)
   end
 
   describe Glossarist::Validation::Rules::PreferredTermRule do
     subject(:rule) { described_class.new }
 
     it "warns when no term is preferred" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { terms: [{ "type" => "expression", "designation" => "test" }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { terms: [{ "type" => "expression", "designation" => "test" }] },
+                                })
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -54,7 +31,7 @@ RSpec.describe "Quality rules" do
     end
 
     it "passes when a term is preferred" do
-      mc = make_concept(id: "1", langs: { eng: {} })
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end
@@ -64,24 +41,23 @@ RSpec.describe "Quality rules" do
     subject(:rule) { described_class.new }
 
     it "warns on duplicate preferred terms across concepts" do
-      c1 = make_concept(id: "1", langs: { eng: {} })
-      c2 = make_concept(id: "2", langs: { eng: {} })
-      ctx = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                            concepts: [c1, c2])
-      expect(rule).to be_applicable(ctx)
-      issues = rule.check(ctx)
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {} }))
+      ds.add_concept(make_managed_concept(id: "2", langs: { eng: {} }))
+      expect(rule).to be_applicable(ds)
+      issues = rule.check(ds)
       expect(issues).not_to be_empty
       expect(issues.first.code).to eq("GLS-302")
     end
 
     it "passes when terms are unique across concepts" do
-      c1 = make_concept(id: "1", langs: { eng: {} })
-      c2 = make_concept(id: "2", langs: {
-                          eng: { terms: [{ "type" => "expression", "designation" => "different", "normative_status" => "preferred" }] },
-                        })
-      ctx = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                            concepts: [c1, c2])
-      expect(rule.check(ctx)).to be_empty
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {} }))
+      ds.add_concept(make_managed_concept(id: "2", langs: {
+                                            eng: { terms: [{ "type" => "expression", "designation" => "different",
+                                                             "normative_status" => "preferred" }] },
+                                          }))
+      expect(rule.check(ds)).to be_empty
     end
   end
 
@@ -89,9 +65,9 @@ RSpec.describe "Quality rules" do
     subject(:rule) { described_class.new }
 
     it "warns on empty definition content" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { definition: [{ "content" => "" }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { definition: [{ "content" => "" }] },
+                                })
       ctx = make_context(mc)
       issues = rule.check(ctx)
       expect(issues).not_to be_empty
@@ -99,7 +75,7 @@ RSpec.describe "Quality rules" do
     end
 
     it "passes for non-empty definition" do
-      mc = make_concept(id: "1", langs: { eng: {} })
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end
@@ -109,9 +85,10 @@ RSpec.describe "Quality rules" do
     subject(:rule) { described_class.new }
 
     it "warns when no authoritative source is defined" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { sources: [{ "type" => "lineage", "origin" => { "ref" => { "source" => "test" } } }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { sources: [{ "type" => "lineage",
+                                                     "origin" => { "ref" => { "source" => "test" } } }] },
+                                })
       ctx = make_context(mc)
       issues = rule.check(ctx)
       expect(issues).not_to be_empty
@@ -119,9 +96,9 @@ RSpec.describe "Quality rules" do
     end
 
     it "passes when authoritative source is present" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { sources: [{ "type" => "authoritative" }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { sources: [{ "type" => "authoritative" }] },
+                                })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end

--- a/spec/unit/validation/rules/schema_rules_spec.rb
+++ b/spec/unit/validation/rules/schema_rules_spec.rb
@@ -2,59 +2,26 @@
 
 require "spec_helper"
 
+# Aggregate spec for schema-family rules. Each rule also has a dedicated
+# _spec.rb with richer coverage; this file is retained as an additional
+# smoke test using real DatasetContext instances (no doubles).
+
 RSpec.describe "Schema rules" do
-  def make_concept(id:, langs: {}, **overrides)
-    mc = Glossarist::ManagedConcept.new(data: { id: id }.merge(overrides))
-    langs.each do |lang, opts|
-      terms = opts[:terms] || [{ "type" => "expression",
-                                 "designation" => "test", "normative_status" => "preferred" }]
-      data = {
-        "language_code" => lang.to_s,
-        "terms" => terms,
-        "definition" => opts[:definition] || [{ "content" => "a definition" }],
-        "entry_status" => opts[:entry_status] || "valid",
-      }
-      data["sources"] = opts[:sources] if opts[:sources]
-      l10n = Glossarist::LocalizedConcept.of_yaml({ "data" => data })
-      mc.add_localization(l10n)
-    end
-    mc
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
 
   def make_context(concept)
-    asset_index = Glossarist::Validation::AssetIndex.new
-    bib_index = Glossarist::Validation::BibliographyIndex.new
-    concept_ids = Set.new([concept.data&.id&.to_s].compact)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                         asset_index: asset_index,
-                         bibliography_index: bib_index,
-                         concept_ids: concept_ids,
-                         declared_languages: %w[eng],
-                         metadata: nil,
-                         gcr?: false)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept,
-      file_name: "concept-#{concept.data.id}.yaml",
-      collection_context: cc,
-    )
+    ds = make_dataset_context(tmpdir)
+    ds.add_concept(concept)
+    make_concept_context(concept, collection_context: ds)
   end
 
   describe Glossarist::Validation::Rules::ConceptStatusRule do
     subject(:rule) { described_class.new }
 
     it "flags invalid concept status" do
-      mc = Glossarist::ManagedConcept.new(data: { id: "1" },
-                                          status: "invalid_status")
-      mc.add_localization(
-        Glossarist::LocalizedConcept.of_yaml({
-                                               "data" => {
-                                                 "language_code" => "eng",
-                                                 "terms" => [{
-                                                   "type" => "expression", "designation" => "t"
-                                                 }],
-                                               },
-                                             }),
-      )
+      mc = make_managed_concept(id: "1", status: "invalid_status",
+                                langs: { eng: {} })
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -67,9 +34,10 @@ RSpec.describe "Schema rules" do
     subject(:rule) { described_class.new }
 
     it "flags invalid source type" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { sources: [{ "type" => "invalid_type", "origin" => { "ref" => { "source" => "test" } } }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { sources: [{ "type" => "invalid_type",
+                                                     "origin" => { "ref" => { "source" => "test" } } }] },
+                                })
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -78,9 +46,9 @@ RSpec.describe "Schema rules" do
     end
 
     it "flags invalid source status" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { sources: [{ "type" => "authoritative", "status" => "bad_status" }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { sources: [{ "type" => "authoritative", "status" => "bad_status" }] },
+                                })
       ctx = make_context(mc)
       issues = rule.check(ctx)
       expect(issues).not_to be_empty
@@ -88,9 +56,9 @@ RSpec.describe "Schema rules" do
     end
 
     it "passes for valid source type and status" do
-      mc = make_concept(id: "1", langs: {
-                          eng: { sources: [{ "type" => "authoritative" }] },
-                        })
+      mc = make_managed_concept(id: "1", langs: {
+                                  eng: { sources: [{ "type" => "authoritative" }] },
+                                })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end
@@ -100,20 +68,9 @@ RSpec.describe "Schema rules" do
     subject(:rule) { described_class.new }
 
     it "flags invalid related concept type" do
-      mc = Glossarist::ManagedConcept.new(data: { id: "1" },
-                                          related: [Glossarist::RelatedConcept.new(
-                                            type: "invalid", content: "x",
-                                          )])
-      mc.add_localization(
-        Glossarist::LocalizedConcept.of_yaml({
-                                               "data" => {
-                                                 "language_code" => "eng",
-                                                 "terms" => [{
-                                                   "type" => "expression", "designation" => "t"
-                                                 }],
-                                               },
-                                             }),
-      )
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
+      mc.related = [Glossarist::RelatedConcept.new(type: "invalid",
+                                                   content: "x")]
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -122,20 +79,9 @@ RSpec.describe "Schema rules" do
     end
 
     it "passes for valid related concept type" do
-      mc = Glossarist::ManagedConcept.new(data: { id: "1" },
-                                          related: [Glossarist::RelatedConcept.new(
-                                            type: "supersedes", content: "x",
-                                          )])
-      mc.add_localization(
-        Glossarist::LocalizedConcept.of_yaml({
-                                               "data" => {
-                                                 "language_code" => "eng",
-                                                 "terms" => [{
-                                                   "type" => "expression", "designation" => "t"
-                                                 }],
-                                               },
-                                             }),
-      )
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
+      mc.related = [Glossarist::RelatedConcept.new(type: "supersedes",
+                                                   content: "x")]
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end

--- a/spec/unit/validation/rules/schema_version_rule_spec.rb
+++ b/spec/unit/validation/rules/schema_version_rule_spec.rb
@@ -5,12 +5,12 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::SchemaVersionRule do
   subject(:rule) { described_class.new }
 
-  let(:concept) { instance_double(Glossarist::ManagedConcept) }
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
   def make_context(concept)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
-    )
+    make_concept_context(concept, collection_context: dataset_context)
   end
 
   describe "#code" do
@@ -36,8 +36,13 @@ RSpec.describe Glossarist::Validation::Rules::SchemaVersionRule do
     end
 
     it "returns false when concept is not a ManagedConcept" do
-      concept = instance_double(Glossarist::LocalizedConcept)
-      expect(rule.applicable?(make_context(concept))).to be false
+      # Construct a real LocalizedConcept (which is not a ManagedConcept)
+      # instead of using instance_double.
+      l10n = Glossarist::LocalizedConcept.of_yaml({
+                                                    "data" => { "language_code" => "eng",
+                                                                "terms" => [{ "type" => "expression", "designation" => "t" }] },
+                                                  })
+      expect(rule.applicable?(make_context(l10n))).to be false
     end
   end
 
@@ -45,8 +50,7 @@ RSpec.describe Glossarist::Validation::Rules::SchemaVersionRule do
     it "passes for schema_version 3" do
       mc = Glossarist::ManagedConcept.new
       mc.schema_version = "3"
-      issues = rule.check(make_context(mc))
-      expect(issues).to be_empty
+      expect(rule.check(make_context(mc))).to be_empty
     end
 
     it "flags missing schema_version" do

--- a/spec/unit/validation/rules/source_urn_format_rule_spec.rb
+++ b/spec/unit/validation/rules/source_urn_format_rule_spec.rb
@@ -5,24 +5,20 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::SourceUrnFormatRule do
   subject(:rule) { described_class.new }
 
-  def make_concept(sources:, domains: [], related: [])
-    l10n = instance_double(Glossarist::LocalizedConcept)
-    allow(l10n).to receive(:data).and_return(
-      instance_double(Glossarist::ConceptData, sources: sources,
-                                               definition: [], notes: [], examples: []),
-    )
-    data = instance_double(Glossarist::ManagedConceptData, domains: domains)
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return([l10n])
-    allow(concept).to receive(:data).and_return(data)
-    allow(concept).to receive(:related).and_return(related)
-    concept
-  end
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
 
   def make_context(concept)
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
+      concept, file_name: "test.yaml", collection_context: dataset_context
     )
+  end
+
+  def make_concept(sources:, domains: [])
+    mc = make_managed_concept(id: "x", langs: { eng: { sources: sources } })
+    mc.data.domains = domains if domains.any?
+    mc
   end
 
   describe "#code" do
@@ -35,9 +31,7 @@ RSpec.describe Glossarist::Validation::Rules::SourceUrnFormatRule do
       origin = Glossarist::Citation.new(ref: ref)
       source = Glossarist::ConceptSource.new(origin: origin)
       concept = make_concept(sources: [source])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      expect(rule.check(make_context(concept))).to be_empty
     end
 
     it "passes for non-URN source" do
@@ -45,9 +39,7 @@ RSpec.describe Glossarist::Validation::Rules::SourceUrnFormatRule do
       origin = Glossarist::Citation.new(ref: ref)
       source = Glossarist::ConceptSource.new(origin: origin)
       concept = make_concept(sources: [source])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      expect(rule.check(make_context(concept))).to be_empty
     end
 
     it "flags malformed URN in source" do
@@ -55,7 +47,6 @@ RSpec.describe Glossarist::Validation::Rules::SourceUrnFormatRule do
       origin = Glossarist::Citation.new(ref: ref)
       source = Glossarist::ConceptSource.new(origin: origin)
       concept = make_concept(sources: [source])
-
       issues = rule.check(make_context(concept))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("malformed URN")
@@ -67,9 +58,7 @@ RSpec.describe Glossarist::Validation::Rules::SourceUrnFormatRule do
         concept_id: "section-3-1",
       )
       concept = make_concept(sources: [], domains: [domain])
-
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      expect(rule.check(make_context(concept))).to be_empty
     end
   end
 end

--- a/spec/unit/validation/rules/structure_rules_spec.rb
+++ b/spec/unit/validation/rules/structure_rules_spec.rb
@@ -2,41 +2,18 @@
 
 require "spec_helper"
 
-RSpec.describe "Structure rules" do
-  def make_concept(id:, langs: {}, **overrides)
-    mc = Glossarist::ManagedConcept.new(data: { id: id }.merge(overrides))
-    langs.each do |lang, opts|
-      terms = opts[:terms] || [{ "type" => "expression",
-                                 "designation" => "test", "normative_status" => "preferred" }]
-      data = {
-        "language_code" => lang.to_s,
-        "terms" => terms,
-        "definition" => opts[:definition] || [{ "content" => "a definition" }],
-        "entry_status" => opts[:entry_status] || "valid",
-      }
-      data["sources"] = opts[:sources] if opts[:sources]
-      l10n = Glossarist::LocalizedConcept.of_yaml({ "data" => data })
-      mc.add_localization(l10n)
-    end
-    mc
-  end
+# Aggregate spec for structure-family rules. Each rule also has a dedicated
+# _spec.rb with richer coverage; this file is retained as an additional
+# smoke test using real DatasetContext instances (no doubles).
 
-  def make_context(concept, stubs = {})
-    asset_index = stubs[:asset_index] || Glossarist::Validation::AssetIndex.new
-    bib_index = stubs[:bibliography_index] || Glossarist::Validation::BibliographyIndex.new
-    concept_ids = stubs[:concept_ids] || Set.new([concept.data&.id&.to_s].compact)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                         asset_index: asset_index,
-                         bibliography_index: bib_index,
-                         concept_ids: concept_ids,
-                         declared_languages: %w[eng],
-                         metadata: nil,
-                         gcr?: false)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept,
-      file_name: "concept-#{concept.data.id}.yaml",
-      collection_context: cc,
-    )
+RSpec.describe "Structure rules" do
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  def make_context(concept)
+    ds = make_dataset_context(tmpdir)
+    ds.add_concept(concept)
+    make_concept_context(concept, collection_context: ds)
   end
 
   describe Glossarist::Validation::Rules::ConceptIdRule do
@@ -44,7 +21,7 @@ RSpec.describe "Structure rules" do
 
     it "flags concept with no id" do
       mc = Glossarist::ManagedConcept.new
-      ctx = make_context(mc, concept_ids: Set.new)
+      ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
       expect(issues).not_to be_empty
@@ -52,7 +29,7 @@ RSpec.describe "Structure rules" do
     end
 
     it "passes for concept with valid id" do
-      mc = make_concept(id: "100")
+      mc = make_managed_concept(id: "100")
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       expect(rule.check(ctx)).to be_empty
@@ -63,12 +40,11 @@ RSpec.describe "Structure rules" do
     subject(:rule) { described_class.new }
 
     it "flags duplicate concept ids" do
-      c1 = make_concept(id: "1", langs: { eng: {} })
-      c2 = make_concept(id: "1", langs: { eng: {} })
-      ctx = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                            concepts: [c1, c2])
-      expect(rule).to be_applicable(ctx)
-      issues = rule.check(ctx)
+      ds = make_dataset_context(tmpdir)
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {} }))
+      ds.add_concept(make_managed_concept(id: "1", langs: { eng: {} }))
+      expect(rule).to be_applicable(ds)
+      issues = rule.check(ds)
       expect(issues).not_to be_empty
       expect(issues.first.message).to include("duplicate id")
     end
@@ -78,14 +54,13 @@ RSpec.describe "Structure rules" do
     subject(:rule) { described_class.new }
 
     it "flags concept with no localizations" do
-      mc = Glossarist::ManagedConcept.new(data: { id: "1" })
+      mc = make_managed_concept(id: "1")
       ctx = make_context(mc)
-      issues = rule.check(ctx)
-      expect(issues).not_to be_empty
+      expect(rule.check(ctx)).not_to be_empty
     end
 
     it "passes for concept with localizations" do
-      mc = make_concept(id: "1", langs: { eng: {} })
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end
@@ -95,7 +70,7 @@ RSpec.describe "Structure rules" do
     subject(:rule) { described_class.new }
 
     it "flags invalid entry_status" do
-      mc = make_concept(id: "1", langs: { eng: { entry_status: "Standard" } })
+      mc = make_managed_concept(id: "1", langs: { eng: { entry_status: "Standard" } })
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -104,7 +79,7 @@ RSpec.describe "Structure rules" do
     end
 
     it "passes for valid entry_status" do
-      mc = make_concept(id: "1", langs: { eng: { entry_status: "valid" } })
+      mc = make_managed_concept(id: "1", langs: { eng: { entry_status: "valid" } })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end
@@ -114,16 +89,8 @@ RSpec.describe "Structure rules" do
     subject(:rule) { described_class.new }
 
     it "flags localization with no terms" do
-      mc = Glossarist::ManagedConcept.new(data: { id: "1" })
-      l10n = Glossarist::LocalizedConcept.of_yaml({
-                                                    "data" => {
-                                                      "language_code" => "eng",
-                                                      "terms" => [],
-                                                      "definition" => [{ "content" => "a definition" }],
-                                                      "entry_status" => "valid",
-                                                    },
-                                                  })
-      mc.add_localization(l10n)
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
+      mc.localization("eng").data.terms = []
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -132,7 +99,7 @@ RSpec.describe "Structure rules" do
     end
 
     it "passes for localization with terms" do
-      mc = make_concept(id: "1", langs: { eng: {} })
+      mc = make_managed_concept(id: "1", langs: { eng: {} })
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end

--- a/spec/unit/validation/rules/uuid_format_rule_spec.rb
+++ b/spec/unit/validation/rules/uuid_format_rule_spec.rb
@@ -5,9 +5,13 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::UuidFormatRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
   def make_context(concept)
     Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
+      concept, file_name: "test.yaml", collection_context: dataset_context
     )
   end
 
@@ -17,29 +21,29 @@ RSpec.describe Glossarist::Validation::Rules::UuidFormatRule do
 
   describe "#check" do
     it "passes for valid UUID" do
-      concept = instance_double(Glossarist::ManagedConcept,
-                                uuid: "0ce27901-02ce-531e-8ba5-fdb136139d1a")
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      mc = make_managed_concept(id: "x")
+      mc.uuid = "0ce27901-02ce-531e-8ba5-fdb136139d1a"
+      expect(rule.check(make_context(mc))).to be_empty
     end
 
     it "passes for nil UUID" do
-      concept = instance_double(Glossarist::ManagedConcept, uuid: nil)
-      issues = rule.check(make_context(concept))
-      expect(issues).to be_empty
+      mc = make_managed_concept(id: "x")
+      mc.uuid = nil
+      expect(rule.check(make_context(mc))).to be_empty
     end
 
     it "flags invalid UUID format" do
-      concept = instance_double(Glossarist::ManagedConcept, uuid: "not-a-uuid")
-      issues = rule.check(make_context(concept))
+      mc = make_managed_concept(id: "x")
+      mc.uuid = "not-a-uuid"
+      issues = rule.check(make_context(mc))
       expect(issues.size).to eq(1)
       expect(issues.first.message).to include("not valid UUID format")
     end
 
     it "flags numeric-only UUID" do
-      concept = instance_double(Glossarist::ManagedConcept, uuid: "12345")
-      issues = rule.check(make_context(concept))
-      expect(issues.size).to eq(1)
+      mc = make_managed_concept(id: "x")
+      mc.uuid = "12345"
+      expect(rule.check(make_context(mc)).size).to eq(1)
     end
   end
 end


### PR DESCRIPTION
## Summary

Second batch of doubles cleanup, continuing #202. **23 more doubles eliminated** across 8 spec files. Combined with #202, **65 doubles removed** total. Per the global "NEVER use doubles in specs" rule.

### Files refactored (8)

| File | Doubles before → after | Notes |
|------|------------------------|-------|
| `integrity_rules_spec.rb` | 4 → 0 | Uses `make_gcr_zip` / `make_gcr_context` helpers from batch 4 |
| `locality_completeness_rule_spec.rb` | 3 → 0 | Real `ConceptSource` + `Citation` + `Locality` instances |
| `quality_rules_spec.rb` | 3 → 0 | Real `DatasetContext` for `PreferredTerm`/`DuplicateTerm`/`DefinitionContent`/`AuthoritativeSource` |
| `schema_rules_spec.rb` | 1 → 0 | Real `DatasetContext` for `ConceptStatus`/`SourceEnum`/`RelatedConcept` |
| `schema_version_rule_spec.rb` | 2 → 0 | Real `ManagedConcept` and real `LocalizedConcept` (for the "not a ManagedConcept" applicable? test — was `instance_double`) |
| `source_urn_format_rule_spec.rb` | 4 → 0 | Real `ConceptSource`/`Citation`/`Ref` objects |
| `structure_rules_spec.rb` | 2 → 0 | Real `DatasetContext` for 5 rule families |
| `uuid_format_rule_spec.rb` | 4 → 0 | Real `ManagedConcept` with explicit `uuid` assignment |

## Test plan

- [x] All 8 refactored spec files pass individually
- [x] `bundle exec rspec` full suite — 1633 examples, 0 failures
- [x] `bundle exec rubocop` — clean

## Remaining doubles (~13, deferred)

Smaller, harder cases:
- `resolution_adapter_spec.rb` (3) — HTTP response mocking, doubles are appropriate here per the rule's "Use lightweight structs for plain data" guidance
- `collection_spec.rb` (3) — legacy collection tests
- `bibliography_collection_spec.rb` (1) — Relaton processor mocking
- 6 single-double files in validation rules — `concept_context_spec`, `related_concept_cycle_rule_spec`, `cite_ref_integrity_rule_spec`, `reference_rules_spec`, `ref_shape_rule_spec`, `related_concept_symmetry_rule_spec` — each has 1 `instance_double(DatasetContext)` for the collection-context fields

These could be a final cleanup batch.
