### PR TITLE
test(validation): replace final doubles in 6 rule specs (batch 3)

### DIFF
--- a/spec/unit/validation/rules/cite_ref_integrity_rule_spec.rb
+++ b/spec/unit/validation/rules/cite_ref_integrity_rule_spec.rb
@@ -24,20 +24,14 @@ RSpec.describe Glossarist::Validation::Rules::CiteRefIntegrityRule do
     mc
   end
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   def make_context(concept, concept_ids: nil)
-    ids = concept_ids || Set.new([concept.data&.id&.to_s].compact)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                         asset_index: Glossarist::Validation::AssetIndex.new,
-                         bibliography_index: Glossarist::Validation::BibliographyIndex.new,
-                         concept_ids: ids,
-                         declared_languages: %w[eng],
-                         metadata: nil,
-                         gcr?: false)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept,
-      file_name: "concept-#{concept.data.id}.yaml",
-      collection_context: cc,
-    )
+    ds = make_dataset_context(tmpdir)
+    ds.add_concept(concept)
+    (concept_ids || []).each { |id| ds.add_concept(make_managed_concept(id: id)) }
+    make_concept_context(concept, collection_context: ds)
   end
 
   describe "unique source ids" do

--- a/spec/unit/validation/rules/concept_context_spec.rb
+++ b/spec/unit/validation/rules/concept_context_spec.rb
@@ -17,16 +17,13 @@ RSpec.describe Glossarist::Validation::Rules::ConceptContext do
     mc
   end
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   let(:collection_context) do
-    instance_double(
-      Glossarist::Validation::Rules::DatasetContext,
-      asset_index: Glossarist::Validation::AssetIndex.new,
-      bibliography_index: Glossarist::Validation::BibliographyIndex.new,
-      concept_ids: Set.new(["1"]),
-      declared_languages: %w[eng],
-      metadata: nil,
-      gcr?: false,
-    )
+    ds = Glossarist::Validation::Rules::DatasetContext.new(tmpdir)
+    ds.add_concept(concept)
+    ds
   end
 
   let(:context) do

--- a/spec/unit/validation/rules/ref_shape_rule_spec.rb
+++ b/spec/unit/validation/rules/ref_shape_rule_spec.rb
@@ -5,24 +5,18 @@ require "spec_helper"
 RSpec.describe Glossarist::Validation::Rules::RefShapeRule do
   subject(:rule) { described_class.new }
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
   def make_concept(sources:, related: [])
-    data = Glossarist::ConceptData.new(
-      sources: sources,
-      definition: [],
-      notes: [],
-      examples: [],
-    )
-    l10n = Glossarist::LocalizedConcept.new(data: data)
-    concept = instance_double(Glossarist::ManagedConcept)
-    allow(concept).to receive(:localizations).and_return([l10n])
-    allow(concept).to receive(:related).and_return(related)
-    concept
+    mc = make_managed_concept(id: "x", langs: { eng: { sources: sources } })
+    mc.related = related if related.any?
+    mc
   end
 
   def make_context(concept)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept, file_name: "test.yaml", collection_context: nil
-    )
+    make_concept_context(concept, collection_context: dataset_context)
   end
 
   describe "#code" do

--- a/spec/unit/validation/rules/reference_rules_spec.rb
+++ b/spec/unit/validation/rules/reference_rules_spec.rb
@@ -3,6 +3,9 @@
 require "spec_helper"
 
 RSpec.describe "Reference rules" do
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   def make_concept(id:, langs: {})
     mc = Glossarist::ManagedConcept.new(data: { id: id })
     langs.each do |lang, opts|
@@ -20,22 +23,11 @@ RSpec.describe "Reference rules" do
     mc
   end
 
-  def make_context(concept, stubs = {})
-    asset_index = stubs[:asset_index] || Glossarist::Validation::AssetIndex.new
-    bib_index = stubs[:bibliography_index] || Glossarist::Validation::BibliographyIndex.new
-    concept_ids = stubs[:concept_ids] || Set.new([concept.data&.id&.to_s].compact)
-    cc = instance_double(Glossarist::Validation::Rules::DatasetContext,
-                         asset_index: asset_index,
-                         bibliography_index: bib_index,
-                         concept_ids: concept_ids,
-                         declared_languages: %w[eng],
-                         metadata: nil,
-                         gcr?: false)
-    Glossarist::Validation::Rules::ConceptContext.new(
-      concept,
-      file_name: "concept-#{concept.data.id}.yaml",
-      collection_context: cc,
-    )
+  def make_context(concept, extra_concept_ids: [])
+    ds = make_dataset_context(tmpdir)
+    ds.add_concept(concept)
+    extra_concept_ids.each { |id| ds.add_concept(make_managed_concept(id: id)) }
+    make_concept_context(concept, collection_context: ds)
   end
 
   describe Glossarist::Validation::Rules::ConceptMentionRule do
@@ -45,7 +37,7 @@ RSpec.describe "Reference rules" do
       mc = make_concept(id: "1", langs: {
                           eng: { definition: [{ "content" => "See {{999, missing}}" }] },
                         })
-      ctx = make_context(mc, concept_ids: Set.new(["1"]))
+      ctx = make_context(mc, extra_concept_ids: ["1"])
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
       expect(issues).not_to be_empty
@@ -56,7 +48,7 @@ RSpec.describe "Reference rules" do
       mc = make_concept(id: "1", langs: {
                           eng: { definition: [{ "content" => "See {{1, test}}" }] },
                         })
-      ctx = make_context(mc, concept_ids: Set.new(["1"]))
+      ctx = make_context(mc, extra_concept_ids: ["1"])
       issues = rule.check(ctx)
       expect(issues).to be_empty
     end

--- a/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
@@ -17,10 +17,13 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptCycleRule do
     rc
   end
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   def make_context(concepts)
-    ctx = instance_double(Glossarist::Validation::Rules::DatasetContext)
-    allow(ctx).to receive(:concepts).and_return(concepts)
-    ctx
+    ds = Glossarist::Validation::Rules::DatasetContext.new(tmpdir)
+    concepts.each { |c| ds.add_concept(c) }
+    ds
   end
 
   it "has correct metadata" do

--- a/spec/unit/validation/rules/related_concept_symmetry_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_symmetry_rule_spec.rb
@@ -19,10 +19,13 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptSymmetryRule do
     rc
   end
 
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
   def make_context(concepts)
-    ctx = instance_double(Glossarist::Validation::Rules::DatasetContext)
-    allow(ctx).to receive(:concepts).and_return(concepts)
-    ctx
+    ds = Glossarist::Validation::Rules::DatasetContext.new(tmpdir)
+    concepts.each { |c| ds.add_concept(c) }
+    ds
   end
 
   it "has correct metadata" do


### PR DESCRIPTION
## Summary

Third and final batch of doubles cleanup for validation rule specs. **6 more doubles eliminated**. Combined with #202 and #203, **71 total doubles removed** across the validation rule spec family. **All validation rule specs are now doubles-free.**

### Files refactored (6)

Each had a single `instance_double(DatasetContext)` or `instance_double(ManagedConcept)`:

- `cite_ref_integrity_rule_spec.rb`
- `concept_context_spec.rb`
- `ref_shape_rule_spec.rb`
- `reference_rules_spec.rb`
- `related_concept_cycle_rule_spec.rb`
- `related_concept_symmetry_rule_spec.rb`

All now use real `DatasetContext` / `ManagedConcept` via the `ValidationRuleSpecHelper` introduced in PR #198. The `reference_rules_spec` caller signature changed from `concept_ids: Set.new([...])` to `extra_concept_ids: [...]` to match the new helper semantics.

## Test plan

- [x] All 6 refactored spec files pass individually
- [x] `bundle exec rspec` full suite — 1633 examples, 0 failures
- [x] `bundle exec rubocop` — clean

## Remaining doubles (~7, outside validation rules)

Genuinely harder cases, deferred:
- `resolution_adapter_spec.rb` (3) — HTTP response mocking; would need a real HTTP stub server
- `collection_spec.rb` (3) — legacy `ManagedConceptCollection` tests
- `bibliography_collection_spec.rb` (1) — Relaton processor mock

These don't fit the "use real model instances" pattern as cleanly — they need either infrastructure (HTTP stubs) or external-library mocking.

## Series summary

| Batch | PR | Files | Doubles removed |
|-------|-----|-------|-----------------|
| 1 | #202 | 5 | 42 |
| 2 | #203 | 8 | 23 |
| 3 | this PR | 6 | 6 |
| **Total** | | **19** | **71** |

Validation rule spec family is now fully doubles-free.
