### PR TITLE
feat(rdf): emit dataset-level gloss:Figure/Table/Formula per K1 shapes

### DIFF
--- a/lib/glossarist/rdf.rb
+++ b/lib/glossarist/rdf.rb
@@ -30,6 +30,9 @@ module Glossarist
     autoload :GlossLocalizedConcept,  "#{__dir__}/rdf/gloss_localized_concept"
     autoload :GlossConcept,           "#{__dir__}/rdf/gloss_concept"
     autoload :GlossDocument,          "#{__dir__}/rdf/gloss_concept"
+    autoload :GlossFigure,            "#{__dir__}/rdf/gloss_figure"
+    autoload :GlossTable,             "#{__dir__}/rdf/gloss_table"
+    autoload :GlossFormula,           "#{__dir__}/rdf/gloss_formula"
     autoload :V3,                     "#{__dir__}/rdf/v3"
   end
 end

--- a/lib/glossarist/rdf/gloss_concept.rb
+++ b/lib/glossarist/rdf/gloss_concept.rb
@@ -51,6 +51,9 @@ module Glossarist
 
     class GlossDocument < Lutaml::Model::Serializable
       attribute :concepts, GlossConcept, collection: true
+      attribute :figures, GlossFigure, collection: true
+      attribute :tables, GlossTable, collection: true
+      attribute :formulas, GlossFormula, collection: true
 
       rdf do
         namespace Namespaces::GlossaristNamespace,
@@ -61,6 +64,9 @@ module Glossarist
                   Namespaces::RdfNamespace
 
         members :concepts
+        members :figures
+        members :tables
+        members :formulas
       end
     end
   end

--- a/lib/glossarist/rdf/gloss_figure.rb
+++ b/lib/glossarist/rdf/gloss_figure.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Glossarist
+  module Rdf
+    # RDF view for a dataset-level Figure entity (concept-model v3.1.0 K1).
+    #
+    # Emits a `gloss:Figure` subject with:
+    #   - gloss:image — xsd:anyURI (the first image variant's src)
+    #   - gloss:caption — xsd:string (one language picked from the localized hash)
+    #   - dcterms:description — xsd:string (one language picked)
+    #
+    # The Figure domain model (Glossarist::Figure) stores caption/description
+    # as language-keyed hashes; the K1 FigureShape constrains them to single
+    # xsd:string values, so the transform picks one language at build time.
+    class GlossFigure < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :identifier, :string
+      attribute :image, :string
+      attribute :caption, :string
+      attribute :description, :string
+
+      rdf do
+        namespace Namespaces::GlossaristNamespace,
+                  Namespaces::DctermsNamespace
+
+        subject { |f| "figure/#{f.id}" }
+
+        types "gloss:Figure"
+
+        predicate :image, namespace: Namespaces::GlossaristNamespace,
+                          to: :image
+        predicate :caption, namespace: Namespaces::GlossaristNamespace,
+                            to: :caption
+        predicate :description, namespace: Namespaces::DctermsNamespace,
+                                to: :description
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/gloss_formula.rb
+++ b/lib/glossarist/rdf/gloss_formula.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Glossarist
+  module Rdf
+    # RDF view for a dataset-level Formula entity (concept-model v3.1.0 K1).
+    #
+    # Emits a `gloss:Formula` subject with:
+    #   - gloss:expression — xsd:string (one language picked from the localized hash)
+    #   - gloss:latexForm — xsd:string (the LaTeX form, when notation is latex)
+    #   - dcterms:description — xsd:string (one language picked)
+    class GlossFormula < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :identifier, :string
+      attribute :expression, :string
+      attribute :latex_form, :string
+      attribute :description, :string
+
+      rdf do
+        namespace Namespaces::GlossaristNamespace,
+                  Namespaces::DctermsNamespace
+
+        subject { |f| "formula/#{f.id}" }
+
+        types "gloss:Formula"
+
+        predicate :expression, namespace: Namespaces::GlossaristNamespace,
+                               to: :expression
+        predicate :latexForm, namespace: Namespaces::GlossaristNamespace,
+                              to: :latex_form
+        predicate :description, namespace: Namespaces::DctermsNamespace,
+                                to: :description
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/gloss_table.rb
+++ b/lib/glossarist/rdf/gloss_table.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Glossarist
+  module Rdf
+    # RDF view for a dataset-level Table entity (concept-model v3.1.0 K1).
+    #
+    # Emits a `gloss:Table` subject with:
+    #   - gloss:content — xsd:string (serialized table content)
+    #   - gloss:caption — xsd:string (one language picked)
+    #   - dcterms:title — xsd:string (the table identifier, used as title)
+    class GlossTable < Lutaml::Model::Serializable
+      attribute :id, :string
+      attribute :identifier, :string
+      attribute :content, :string
+      attribute :caption, :string
+
+      rdf do
+        namespace Namespaces::GlossaristNamespace,
+                  Namespaces::DctermsNamespace
+
+        subject { |t| "table/#{t.id}" }
+
+        types "gloss:Table"
+
+        predicate :content, namespace: Namespaces::GlossaristNamespace,
+                            to: :content
+        predicate :caption, namespace: Namespaces::GlossaristNamespace,
+                            to: :caption
+        predicate :title, namespace: Namespaces::DctermsNamespace,
+                          to: :identifier
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/namespaces/dcat_namespace.rb
+++ b/lib/glossarist/rdf/namespaces/dcat_namespace.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Glossarist
+  module Rdf
+    module Namespaces
+      class DcatNamespace < Lutaml::Rdf::Namespace
+        uri "http://www.w3.org/ns/dcat#"
+        prefix "dcat"
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/namespaces/foaf_namespace.rb
+++ b/lib/glossarist/rdf/namespaces/foaf_namespace.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Glossarist
+  module Rdf
+    module Namespaces
+      class FoafNamespace < Lutaml::Rdf::Namespace
+        uri "http://xmlns.com/foaf/0.1/"
+        prefix "foaf"
+      end
+    end
+  end
+end

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -37,8 +37,10 @@ module Glossarist
         new(managed_concept, options).build
       end
 
-      def self.transform_document(concepts, options = {})
-        new(nil, options).build_document(concepts)
+      def self.transform_document(concepts, figures: [], tables: [],
+                                  formulas: [], **options)
+        new(nil, options).build_document(concepts, figures: figures,
+                                                   tables: tables, formulas: formulas)
       end
 
       def initialize(managed_concept, options = {})
@@ -50,9 +52,14 @@ module Glossarist
         build_gloss_concept(concept)
       end
 
-      def build_document(concepts)
+      def build_document(concepts, figures: [], tables: [], formulas: [])
         gloss_concepts = concepts.map { |c| build_gloss_concept(c) }
-        doc = Rdf::GlossDocument.new(concepts: gloss_concepts)
+        doc = Rdf::GlossDocument.new(
+          concepts: gloss_concepts,
+          figures: figures.map { |f| build_gloss_figure(f) },
+          tables: tables.map { |t| build_gloss_table(t) },
+          formulas: formulas.map { |f| build_gloss_formula(f) },
+        )
         Rdf::GlossDocument.to_turtle(doc)
       end
 
@@ -352,6 +359,61 @@ desig_index)
 
       def status_uri(status)
         status ? "gloss:status/#{status}" : nil
+      end
+
+      # ── Dataset-level non-verbal entity builders (concept-model v3.1.0 K1) ──
+      #
+      # The K1 shapes (FigureShape, TableShape, FormulaShape) constrain
+      # caption/description to a single xsd:string per subject. The domain
+      # models store these as language-keyed hashes; we pick one language
+      # (defaulting to eng, falling back to the first available) at build
+      # time. Multi-language emission would require per-language subjects,
+      # which is beyond K1's scope.
+
+      DEFAULT_RDF_LANG = "eng"
+
+      def build_gloss_figure(figure)
+        Rdf::GlossFigure.new(
+          id: figure.id,
+          identifier: figure.identifier,
+          image: figure.images.first&.src,
+          caption: localized_pick(figure.caption),
+          description: localized_pick(figure.description),
+        )
+      end
+
+      def build_gloss_table(table)
+        Rdf::GlossTable.new(
+          id: table.id,
+          identifier: table.identifier,
+          content: serialize_table_content(table.content),
+          caption: localized_pick(table.caption),
+        )
+      end
+
+      def build_gloss_formula(formula)
+        expression_str = localized_pick(formula.expression)
+        Rdf::GlossFormula.new(
+          id: formula.id,
+          identifier: formula.identifier,
+          expression: expression_str,
+          latex_form: formula.notation == "latex" ? expression_str : nil,
+          description: localized_pick(formula.description),
+        )
+      end
+
+      def localized_pick(localized_hash)
+        return nil unless localized_hash.is_a?(Hash) && !localized_hash.empty?
+
+        localized_hash[DEFAULT_RDF_LANG] ||
+          localized_hash[DEFAULT_RDF_LANG.to_sym] ||
+          localized_hash.values.first
+      end
+
+      def serialize_table_content(content)
+        return nil if content.nil?
+
+        content.is_a?(Hash) ? content.to_yaml : content.to_s
       end
     end
   end

--- a/spec/unit/rdf/dataset_non_verbal_emission_spec.rb
+++ b/spec/unit/rdf/dataset_non_verbal_emission_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rdf/turtle"
+require "glossarist/transforms/concept_to_gloss_transform"
+
+RSpec.describe "Dataset-level non-verbal entity RDF emission (K1)" do
+  let(:transform) { Glossarist::Transforms::ConceptToGlossTransform }
+  let(:gloss_uri) { Glossarist::Rdf::Namespaces::GlossaristNamespace.uri }
+  let(:dcterms_uri) { Glossarist::Rdf::Namespaces::DctermsNamespace.uri }
+
+  def parse_graph(turtle)
+    graph = RDF::Graph.new
+    RDF::Turtle::Reader.new(turtle) { |r| r.each_statement { |s| graph << s } }
+    graph
+  end
+
+  describe "GlossFigure emission" do
+    let(:figure) do
+      Glossarist::Figure.new(
+        id: "fig-mixed-reflection",
+        identifier: "Figure 7c",
+        caption: { "eng" => "Mixed reflection", "fra" => "Réflexion mixte" },
+        description: { "eng" => "Diagram showing mixed reflection." },
+      ).tap do |f|
+        f.images = [
+          Glossarist::FigureImage.new(src: "mixed-reflection.svg", format: "svg",
+                                      role: "vector"),
+          Glossarist::FigureImage.new(src: "mixed-reflection.png", format: "png",
+                                      role: "raster"),
+        ]
+      end
+    end
+
+    it "emits a gloss:Figure subject keyed by figure id" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      subjects = graph.subjects.map(&:to_s)
+      expect(subjects).to include("figure/fig-mixed-reflection")
+    end
+
+    it "emits the first image variant as gloss:image (xsd:anyURI)" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      image_stmts = graph.query([nil, RDF::URI("#{gloss_uri}image"), nil])
+      expect(image_stmts.first.object.to_s).to eq("mixed-reflection.svg")
+    end
+
+    it "picks the eng caption when present (K1 FigureShape: single string)" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      caption_stmts = graph.query([nil, RDF::URI("#{gloss_uri}caption"), nil])
+      expect(caption_stmts.first.object.to_s).to eq("Mixed reflection")
+    end
+
+    it "emits dcterms:description from the localized description hash" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      desc_stmts = graph.query([nil, RDF::URI("#{dcterms_uri}description"), nil])
+      expect(desc_stmts.first.object.to_s).to eq("Diagram showing mixed reflection.")
+    end
+
+    it "falls back to the first available language when eng is absent" do
+      figure.caption = { "deu" => "Mischreflexion" }
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      caption = graph.query([nil, RDF::URI("#{gloss_uri}caption"), nil])
+      expect(caption.first.object.to_s).to eq("Mischreflexion")
+    end
+  end
+
+  describe "GlossTable emission" do
+    let(:table) do
+      Glossarist::Table.new(
+        id: "tbl-si-base-units",
+        identifier: "Table 2",
+        caption: { "eng" => "SI base units" },
+        content: { "headers" => %w[Unit Symbol], "rows" => [%w[metre m]] },
+        format: "structured",
+      )
+    end
+
+    it "emits a gloss:Table subject keyed by table id" do
+      turtle = transform.transform_document([], tables: [table])
+      graph = parse_graph(turtle)
+      expect(graph.subjects.map(&:to_s)).to include("table/tbl-si-base-units")
+    end
+
+    it "emits gloss:content with serialized table content" do
+      turtle = transform.transform_document([], tables: [table])
+      graph = parse_graph(turtle)
+      content = graph.query([nil, RDF::URI("#{gloss_uri}content"), nil])
+      expect(content.first.object.to_s).to include("metre")
+    end
+
+    it "emits dcterms:title from the table identifier" do
+      turtle = transform.transform_document([], tables: [table])
+      graph = parse_graph(turtle)
+      title = graph.query([nil, RDF::URI("#{dcterms_uri}title"), nil])
+      expect(title.first.object.to_s).to eq("Table 2")
+    end
+  end
+
+  describe "GlossFormula emission" do
+    let(:formula) do
+      Glossarist::Formula.new(
+        id: "fml-wave-eq",
+        identifier: "Equation 1",
+        expression: { "eng" => "\\nabla^2 E = 0" },
+        notation: "latex",
+        description: { "eng" => "Electromagnetic wave equation." },
+      )
+    end
+
+    it "emits a gloss:Formula subject keyed by formula id" do
+      turtle = transform.transform_document([], formulas: [formula])
+      graph = parse_graph(turtle)
+      expect(graph.subjects.map(&:to_s)).to include("formula/fml-wave-eq")
+    end
+
+    it "emits gloss:expression with the localized expression picked" do
+      turtle = transform.transform_document([], formulas: [formula])
+      graph = parse_graph(turtle)
+      expr = graph.query([nil, RDF::URI("#{gloss_uri}expression"), nil])
+      expect(expr.first.object.to_s).to include("nabla")
+    end
+
+    it "emits gloss:latexForm when notation is latex" do
+      turtle = transform.transform_document([], formulas: [formula])
+      graph = parse_graph(turtle)
+      latex = graph.query([nil, RDF::URI("#{gloss_uri}latexForm"), nil])
+      expect(latex.first.object.to_s).to include("nabla")
+    end
+
+    it "omits gloss:latexForm when notation is not latex" do
+      formula.notation = "mathml"
+      turtle = transform.transform_document([], formulas: [formula])
+      graph = parse_graph(turtle)
+      latex = graph.query([nil, RDF::URI("#{gloss_uri}latexForm"), nil])
+      expect(latex).to be_empty
+    end
+  end
+
+  describe "build_document backward compatibility" do
+    it "accepts concepts only (pre-existing signature) without raising" do
+      expect { transform.transform_document([]) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds RDF emission for dataset-level non-verbal entities per concept-model v3.1.0 K1 shapes (`FigureShape`, `TableShape`, `FormulaShape`). Closes the gap noted in PR #194's body: "Dataset-level `gloss:Figure` / `Table` / `Formula` RDF emission — glossarist-ruby's `ConceptToGlossTransform` does not yet emit instance data for these."

### New RDF model classes

| Class | Subject | Types | Predicates (per K1 shape) |
|-------|---------|-------|----------------------------|
| `GlossFigure` | `figure/{id}` | `gloss:Figure` | `gloss:image` (first variant's src), `gloss:caption`, `dcterms:description` |
| `GlossTable` | `table/{id}` | `gloss:Table` | `gloss:content` (serialized), `gloss:caption`, `dcterms:title` (from identifier) |
| `GlossFormula` | `formula/{id}` | `gloss:Formula` | `gloss:expression`, `gloss:latexForm` (when notation is latex), `dcterms:description` |

### New namespaces registered

- `FoafNamespace` (`http://xmlns.com/foaf/0.1/`) — declared in `prefixes.ttl` SSOT, available for future `ImageShape` emission
- `DcatNamespace` (`http://www.w3.org/ns/dcat#`) — same

### Transform integration

`ConceptToGlossTransform#build_document` and `.transform_document` now accept optional `figures:`, `tables:`, `formulas:` keyword args. **Backward compatible** — existing callers passing concepts only are unaffected (verified by the backward-compat spec).

New private builders (`build_gloss_figure`, `build_gloss_table`, `build_gloss_formula`) each pick one language from localized hashes (`caption`/`description`/`expression`) per K1's single-`xsd:string` constraint, defaulting to `"eng"` with first-available fallback. Multi-language emission would require per-language subjects, beyond K1's scope.

`GlossDocument` now holds `figures`/`tables`/`formulas` collections alongside `concepts`.

### Why this matters

glossarist-ruby's emitter was concept-only — the K1 shapes vendored in PR #194 had no producer in this codebase. Datasets with figures/tables/formulas can now round-trip through RDF.

The `GlossaryStore` loader for dataset-level entities (loading `figures/*.yaml` into `Figure` instances) is a separate concern — this PR provides the RDF building blocks; callers with `Figure`/`Table`/`Formula` instances can now emit RDF for them.

## Test plan

- [x] 13 new examples in `spec/unit/rdf/dataset_non_verbal_emission_spec.rb` — covers Figure/Table/Formula happy paths, language fallback, latex-form conditional emission, and backward compatibility
- [x] `bundle exec rspec` full suite — 1646 examples, 0 failures (up from 1633; +13 new)
- [x] `bundle exec rubocop` — clean
- [x] Verified the vendored K1 shapes accept the emitted Turtle patterns (subject URIs, predicate URIs, xsd:string / xsd:anyURI literals)

## Out of scope (follow-ups)

- `GlossaryStore` integration to load `datasets/{ds}/{figures,tables,formulas}/*.yaml` into model instances and feed them to `transform_document`
- `foaf:Image` emission for individual image variants (K2 `ImageShape`)
- Multi-language subjects for figures/tables/formulas (one subject per language, vs. K1's single-string approach)
