### PR TITLE
test: replace final doubles — spec suite is now doubles-free

### DIFF
--- a/spec/unit/collection/bibliography_collection_spec.rb
+++ b/spec/unit/collection/bibliography_collection_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe Glossarist::Collections::BibliographyCollection do
     it "raises CacheVersionMismatchError on fetch_all when version is wrong" do
       File.write("#{iso_dir}/version", "wrong")
 
-      processor = instance_double("processor", grammar_hash: "correct_hash")
+      # Lightweight processor stub: Relaton processors respond to #grammar_hash.
+      # Use a Struct instead of instance_double per the global "no doubles" rule.
+      processor = Struct.new(:grammar_hash).new("correct_hash")
       allow(Relaton::Registry.instance).to receive(:by_type)
         .with("iso").and_return(processor)
 

--- a/spec/unit/collection_spec.rb
+++ b/spec/unit/collection_spec.rb
@@ -4,10 +4,15 @@
 #
 
 RSpec.describe Glossarist::Collection do
-  let(:collection_index) { subject.instance_variable_get :@index }
+  # Use a lightweight Struct instead of double() per the global "no doubles"
+  # rule. The Collection only needs an object that responds to #id.
+  let(:concept_struct) { Struct.new(:id) }
+  let(:concept1234) { concept_struct.new("1234") }
+  let(:concept3456) { concept_struct.new("3456") }
 
-  let(:concept1234) { double("concept 1234", id: "1234") }
-  let(:concept3456) { double("concept 3456", id: "3456") }
+  def collection_index
+    subject.instance_variable_get(:@index)
+  end
 
   it "includes Enumerable module" do
     expect(subject).to be_kind_of(Enumerable)
@@ -63,7 +68,7 @@ RSpec.describe Glossarist::Collection do
     end
 
     it "replaces concept of the same ID if one is already in the collection" do
-      collection_index["1234"] = double("old 1234")
+      collection_index["1234"] = concept_struct.new("old-1234")
 
       expect { subject.store(concept1234) }
         .to preserve { collection_index.size }
@@ -101,9 +106,9 @@ RSpec.describe Glossarist::Collection do
       allow(File).to receive(:read).with("path2").and_return("data: 2")
 
       expect(Glossarist::Concept)
-        .to receive(:from_yaml).with("data: 1").and_return(double(id: 1))
+        .to receive(:from_yaml).with("data: 1").and_return(concept_struct.new(1))
       expect(Glossarist::Concept)
-        .to receive(:from_yaml).with("data: 2").and_return(double(id: 2))
+        .to receive(:from_yaml).with("data: 2").and_return(concept_struct.new(2))
 
       expect { subject.load_concepts }.to change { collection_index.size }.by(2)
     end
@@ -112,13 +117,16 @@ RSpec.describe Glossarist::Collection do
   describe "#save_concepts" do
     before { allow(subject).to receive(:path).and_return("concepts/path") }
 
-    before { collection_index["1234"] = concept1234 }
-    before { collection_index["3456"] = concept3456 }
+    # Use a Struct that responds to #to_h, replacing the doubles that
+    # expected :to_h via rspec mocks.
+    let(:savable_concept) { Struct.new(:id, :payload) { def to_h = payload } }
+    let(:savable_1234) { savable_concept.new("1234", { data: 1234 }) }
+    let(:savable_3456) { savable_concept.new("3456", { data: 3456 }) }
+
+    before { collection_index["1234"] = savable_1234 }
+    before { collection_index["3456"] = savable_3456 }
 
     it "writes concepts to YAMLs" do
-      expect(concept1234).to receive(:to_h).and_return({ data: 1234 })
-      expect(concept3456).to receive(:to_h).and_return({ data: 3456 })
-
       expect(File).to receive(:write)
         .with("concepts/path/concept-1234.yaml", /data: 1234/)
       expect(File).to receive(:write)

--- a/spec/unit/resolution_adapter_spec.rb
+++ b/spec/unit/resolution_adapter_spec.rb
@@ -1,11 +1,35 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "net/http"
 
 RSpec.describe Glossarist::ResolutionAdapter::Remote do
   let(:adapter) do
     described_class.new(uri_prefix: "urn:iec:std:iec:60050",
                         endpoint: "https://example.org/api")
+  end
+
+  # Lightweight HTTP response stub. Implements the subset of Net::HTTPResponse
+  # the adapter actually uses: is_a?(Net::HTTPSuccess) via kind_of?, the
+  # content-type header via [], and #body. Replaces double("response", ...)
+  # per the global "no doubles" rule.
+  class FakeHttpResponse
+    def initialize(success:, content_type: "application/json", body: "")
+      @success = success
+      @content_type = content_type
+      @body = body
+    end
+
+    def is_a?(klass)
+      klass == Net::HTTPSuccess ? @success : super
+    end
+    alias kind_of? is_a?
+
+    def [](_header)
+      @content_type
+    end
+
+    attr_reader :body
   end
 
   describe "#resolve" do
@@ -17,17 +41,19 @@ RSpec.describe Glossarist::ResolutionAdapter::Remote do
 
     it "returns nil for unmatched uri_prefix" do
       ref = Glossarist::ConceptReference.new(term: "test", concept_id: "1",
-                                             source: "urn:iso:std:iso:19111", ref_type: "urn")
+                                             source: "urn:iso:std:iso:19111",
+                                             ref_type: "urn")
       expect(adapter.resolve(ref)).to be_nil
     end
 
     it "returns parsed JSON for matching reference" do
-      ref = Glossarist::ConceptReference.new(term: "equality", concept_id: "102-01-01",
-                                             source: "urn:iec:std:iec:60050", ref_type: "urn")
+      ref = Glossarist::ConceptReference.new(term: "equality",
+                                             concept_id: "102-01-01",
+                                             source: "urn:iec:std:iec:60050",
+                                             ref_type: "urn")
 
-      body = '{"termid":"102-01-01"}'
-      response = double("response", is_a?: true, "[]": "application/json",
-                                    body: body)
+      response = FakeHttpResponse.new(success: true,
+                                      body: '{"termid":"102-01-01"}')
       allow(Net::HTTP).to receive(:get_response).and_return(response)
 
       result = adapter.resolve(ref)
@@ -35,12 +61,13 @@ RSpec.describe Glossarist::ResolutionAdapter::Remote do
     end
 
     it "caches results across calls" do
-      ref = Glossarist::ConceptReference.new(term: "equality", concept_id: "102-01-01",
-                                             source: "urn:iec:std:iec:60050", ref_type: "urn")
+      ref = Glossarist::ConceptReference.new(term: "equality",
+                                             concept_id: "102-01-01",
+                                             source: "urn:iec:std:iec:60050",
+                                             ref_type: "urn")
 
-      body = '{"termid":"102-01-01"}'
-      response = double("response", is_a?: true, "[]": "application/json",
-                                    body: body)
+      response = FakeHttpResponse.new(success: true,
+                                      body: '{"termid":"102-01-01"}')
       allow(Net::HTTP).to receive(:get_response).and_return(response)
 
       adapter.resolve(ref)
@@ -49,18 +76,22 @@ RSpec.describe Glossarist::ResolutionAdapter::Remote do
     end
 
     it "returns nil on network error" do
-      ref = Glossarist::ConceptReference.new(term: "equality", concept_id: "102-01-01",
-                                             source: "urn:iec:std:iec:60050", ref_type: "urn")
+      ref = Glossarist::ConceptReference.new(term: "equality",
+                                             concept_id: "102-01-01",
+                                             source: "urn:iec:std:iec:60050",
+                                             ref_type: "urn")
       allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
 
       expect(adapter.resolve(ref)).to be_nil
     end
 
     it "returns nil on non-success HTTP response" do
-      ref = Glossarist::ConceptReference.new(term: "equality", concept_id: "102-01-01",
-                                             source: "urn:iec:std:iec:60050", ref_type: "urn")
+      ref = Glossarist::ConceptReference.new(term: "equality",
+                                             concept_id: "102-01-01",
+                                             source: "urn:iec:std:iec:60050",
+                                             ref_type: "urn")
 
-      response = double("response", is_a?: false)
+      response = FakeHttpResponse.new(success: false)
       allow(Net::HTTP).to receive(:get_response).and_return(response)
 
       expect(adapter.resolve(ref)).to be_nil


### PR DESCRIPTION
Final doubles cleanup across collection, resolution_adapter, and bibliography_collection specs. With this PR, zero double()/instance_double() calls remain across the entire spec suite. Per the global 'NEVER use doubles' rule.

Files refactored (3):
- collection_spec.rb (3→0): Struct.new(:id) replaces bare doubles
- resolution_adapter_spec.rb (3→0): FakeHttpResponse stub class replaces HTTP response doubles
- bibliography_collection_spec.rb (1→0): Struct.new(:grammar_hash) replaces Relaton processor double

Also encapsulated instance_variable_get(:@index) behind a helper method.

Series total: 78 doubles removed across 22 files (PRs #202, #203, #204, this). Suite is fully doubles-free.

Tests: 1646 examples, 0 failures.