### PR TITLE
feat(store): wire dataset-level NVR entities + fix lutaml_ext autoload

### DIFF
--- a/lib/glossarist/cli/export_command.rb
+++ b/lib/glossarist/cli/export_command.rb
@@ -52,13 +52,17 @@ module Glossarist
       private
 
       def load_concepts
-        if @path.end_with?(".gcr")
-          package = GcrPackage.load(@path)
-          resolve_metadata_from_package(package)
-          package.concepts
-        else
-          GlossaryStore.new.tap { |s| s.load(@path) }.concepts
-        end
+        store.concepts
+      end
+
+      def store
+        @store ||= if @path.end_with?(".gcr")
+                     pkg = GcrPackage.load(@path)
+                     resolve_metadata_from_package(pkg)
+                     pkg
+                   else
+                     GlossaryStore.new.tap { |s| s.load(@path) }
+                   end
       end
 
       def resolve_metadata_from_package(package)
@@ -106,6 +110,22 @@ module Glossarist
         @options.fetch(:validate, false)
       end
 
+      # Dataset-level non-verbal entities come from the GlossaryStore (which
+      # lazy-loads figures/tables/formulas from the dataset directory). GCR
+      # packages don't yet expose these — empty arrays keep the call site
+      # uniform. Future: extend GcrPackage to surface them.
+      def dataset_figures
+        @store.is_a?(GlossaryStore) ? @store.figures : []
+      end
+
+      def dataset_tables
+        @store.is_a?(GlossaryStore) ? @store.tables : []
+      end
+
+      def dataset_formulas
+        @store.is_a?(GlossaryStore) ? @store.formulas : []
+      end
+
       def per_concept_supported?(format)
         PER_CONCEPT_FORMATS.include?(format)
       end
@@ -136,7 +156,10 @@ module Glossarist
         transform = Transforms::ConceptToGlossTransform.new(nil,
                                                             transform_options)
         File.write(File.join(output_dir, "#{name}.jsonld"),
-                   transform.to_jsonld(concepts))
+                   transform.to_jsonld(concepts,
+                                       figures: dataset_figures,
+                                       tables: dataset_tables,
+                                       formulas: dataset_formulas))
       end
 
       def export_turtle(concepts, name, output_dir)
@@ -144,7 +167,10 @@ module Glossarist
         transform = Transforms::ConceptToGlossTransform.new(nil,
                                                             transform_options)
         File.write(File.join(output_dir, "#{name}.ttl"),
-                   transform.to_turtle(concepts))
+                   transform.to_turtle(concepts,
+                                       figures: dataset_figures,
+                                       tables: dataset_tables,
+                                       formulas: dataset_formulas))
       end
 
       def export_tbx(concepts, name, output_dir)

--- a/lib/glossarist/glossary_store.rb
+++ b/lib/glossarist/glossary_store.rb
@@ -9,11 +9,16 @@ module Glossarist
       @concept_document_class = V3::ConceptDocument
       @v1_concepts = nil
       @localized_concepts_dir_name = nil
+      @dataset_path = nil
+      @figures = nil
+      @tables = nil
+      @formulas = nil
     end
 
     # ── Load ──
 
     def load_directory(path, format: nil)
+      @dataset_path = File.expand_path(path)
       if v1_dataset?(path)
         load_v1_fallback(path)
         return self
@@ -44,6 +49,7 @@ module Glossarist
     end
 
     def load_zip(path, format: nil)
+      @dataset_path = File.expand_path(path)
       metadata = load_metadata_from_zip(path)
       @concept_document_class = resolve_concept_document_class(metadata)
 
@@ -174,6 +180,28 @@ module Glossarist
       @package.asset_paths.select { |p| p.start_with?("images/") }
     end
 
+    # ── Dataset-level non-verbal entities ──
+    #
+    # Loaded lazily from the dataset's figures/, tables/, formulas/
+    # subdirectories. Each YAML file is parsed as the corresponding model
+    # (Figure, Table, Formula). The entities are referenced from
+    # ManagedConceptData via FigureReference/TableReference/FormulaReference
+    # but live as standalone shared entities at the dataset level.
+    # Wired into ConceptToGlossTransform via the figures:/tables:/formulas:
+    # kwargs on transform_document.
+
+    def figures
+      @figures ||= load_dataset_entities("figures", Figure)
+    end
+
+    def tables
+      @tables ||= load_dataset_entities("tables", Table)
+    end
+
+    def formulas
+      @formulas ||= load_dataset_entities("formulas", Formula)
+    end
+
     # ── Stats ──
 
     def stats
@@ -199,6 +227,21 @@ module Glossarist
         concept_document_class: @concept_document_class,
       )
       @package = Lutaml::Store::PackageStore.new(definition)
+    end
+
+    # Scans `{dataset_path}/{subdir}/*.{yaml,yml}` and parses each file as
+    # the given model class. Returns [] when the directory doesn't exist
+    # (e.g., datasets that don't carry this entity kind) — absent directory
+    # is not an error, just an empty collection.
+    def load_dataset_entities(subdir, klass)
+      return [] unless @dataset_path
+
+      dir = File.join(@dataset_path, subdir)
+      return [] unless File.directory?(dir)
+
+      Dir.glob(File.join(dir, "*.{yaml,yml}")).filter_map do |path|
+        klass.from_file(path)
+      end
     end
 
     def resolve_concept_document_class(metadata)

--- a/lib/glossarist/rdf.rb
+++ b/lib/glossarist/rdf.rb
@@ -4,10 +4,18 @@ require "lutaml/rdf"
 require "lutaml/turtle"
 require "lutaml/jsonld"
 
-require_relative "rdf/lutaml_ext"
-
 module Glossarist
   module Rdf
+    # lutaml_ext.rb defines EmitsExtraTriples (mixed into RDF model classes
+    # that want to emit extra triples) and LutamlTurtleTransformExt (prepended
+    # into Lutaml::Turtle::Transform so the framework asks each instance for
+    # its extra triples). The prepend must run before the first transform
+    # call; autoload here fires the first time EmitsExtraTriples is
+    # referenced (i.e., when GlossLocalizedConcept includes it during its
+    # own autoload), which is before any transform runs.
+    autoload :EmitsExtraTriples,        "#{__dir__}/rdf/lutaml_ext"
+    autoload :LutamlTurtleTransformExt, "#{__dir__}/rdf/lutaml_ext"
+
     autoload :Namespaces,             "#{__dir__}/rdf/namespaces"
     autoload :LocalizedLiteral,       "#{__dir__}/rdf/localized_literal"
     autoload :RelationshipPredicates, "#{__dir__}/rdf/relationship_predicates"

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -63,9 +63,11 @@ module Glossarist
         Rdf::GlossDocument.to_turtle(doc)
       end
 
-      def to_turtle(concepts_or_concept = nil)
+      def to_turtle(concepts_or_concept = nil, figures: [], tables: [],
+                    formulas: [])
         if concepts_or_concept.is_a?(Array)
-          build_document(concepts_or_concept)
+          build_document(concepts_or_concept, figures: figures,
+                                              tables: tables, formulas: formulas)
         else
           target = concepts_or_concept || @concept
           return "" unless target
@@ -75,12 +77,18 @@ module Glossarist
         end
       end
 
-      def to_jsonld(concepts_or_concept = nil)
+      def to_jsonld(concepts_or_concept = nil, figures: [], tables: [],
+                    formulas: [])
         if concepts_or_concept.is_a?(Array)
           gloss_concepts = concepts_or_concept.map do |c|
             build_gloss_concept(c)
           end
-          doc = Rdf::GlossDocument.new(concepts: gloss_concepts)
+          doc = Rdf::GlossDocument.new(
+            concepts: gloss_concepts,
+            figures: figures.map { |f| build_gloss_figure(f) },
+            tables: tables.map { |t| build_gloss_table(t) },
+            formulas: formulas.map { |f| build_gloss_formula(f) },
+          )
           Rdf::GlossDocument.to_jsonld(doc)
         else
           target = concepts_or_concept || @concept

--- a/spec/unit/glossary_store_spec.rb
+++ b/spec/unit/glossary_store_spec.rb
@@ -379,4 +379,117 @@ RSpec.describe Glossarist::GlossaryStore do
     end
     zip_path
   end
+
+  describe "dataset-level non-verbal entities (figures/tables/formulas)" do
+    # End-to-end: the dataset directory carries figures/, tables/, formulas/
+    # subdirectories with YAML entities; GlossaryStore lazy-loads them via
+    # #figures, #tables, #formulas. Wiring into ConceptToGlossTransform
+    # (transform_document kwargs) makes the K1 RDF path reachable from a
+    # plain dataset directory load.
+    let(:figure_yaml) do
+      <<~YAML
+        ---
+        id: fig-mixed-reflection
+        identifier: Figure 7c
+        caption:
+          eng: Mixed reflection
+        description:
+          eng: Diagram showing mixed reflection.
+        images:
+        - src: mixed-reflection.svg
+          format: svg
+          role: vector
+      YAML
+    end
+
+    let(:table_yaml) do
+      <<~YAML
+        ---
+        id: tbl-si-units
+        identifier: Table 2
+        caption:
+          eng: SI base units
+        content:
+          headers: [Unit, Symbol]
+          rows: [[metre, m]]
+      YAML
+    end
+
+    let(:formula_yaml) do
+      <<~YAML
+        ---
+        id: fml-wave-eq
+        identifier: Equation 1
+        expression:
+          eng: \\nabla^2 E = 0
+        notation: latex
+      YAML
+    end
+
+    let(:nvr_dataset_dir) do
+      dir = File.join(tmpdir, "nvr-dataset")
+      %w[figures tables formulas].each do |sub|
+        sub_dir = File.join(dir, sub)
+        FileUtils.mkdir_p(sub_dir)
+      end
+      File.write(File.join(dir, "figures", "fig-mixed-reflection.yaml"),
+                 figure_yaml, encoding: "utf-8")
+      File.write(File.join(dir, "tables", "tbl-si-units.yaml"),
+                 table_yaml, encoding: "utf-8")
+      File.write(File.join(dir, "formulas", "fml-wave-eq.yaml"),
+                 formula_yaml, encoding: "utf-8")
+      dir
+    end
+
+    it "#figures returns Figure instances with parsed fields" do
+      store.load_directory(nvr_dataset_dir)
+      figure = store.figures.first
+      expect(figure).to be_a(Glossarist::Figure)
+      expect(figure.id).to eq("fig-mixed-reflection")
+      expect(figure.caption["eng"]).to eq("Mixed reflection")
+      expect(figure.images.first.src).to eq("mixed-reflection.svg")
+    end
+
+    it "#tables returns Table instances with parsed content" do
+      store.load_directory(nvr_dataset_dir)
+      table = store.tables.first
+      expect(table).to be_a(Glossarist::Table)
+      expect(table.id).to eq("tbl-si-units")
+      expect(table.content["headers"]).to eq(%w[Unit Symbol])
+    end
+
+    it "#formulas returns Formula instances with parsed expression" do
+      store.load_directory(nvr_dataset_dir)
+      formula = store.formulas.first
+      expect(formula).to be_a(Glossarist::Formula)
+      expect(formula.id).to eq("fml-wave-eq")
+      expect(formula.expression["eng"]).to include("nabla")
+    end
+
+    it "returns empty arrays when the subdirectory is absent" do
+      minimal = File.join(tmpdir, "minimal")
+      FileUtils.mkdir_p(File.join(minimal, "concepts"))
+      store.load_directory(minimal)
+      expect(store.figures).to eq([])
+      expect(store.tables).to eq([])
+      expect(store.formulas).to eq([])
+    end
+
+    it "lazy-loads on first access (memoized)" do
+      store.load_directory(nvr_dataset_dir)
+      expect(store.figures).to be(store.figures) # same object on second call
+    end
+
+    it "end-to-end: transform_document emits gloss:Figure subjects" do
+      require "glossarist/transforms/concept_to_gloss_transform"
+      store.load_directory(nvr_dataset_dir)
+      turtle = Glossarist::Transforms::ConceptToGlossTransform
+        .transform_document([], figures: store.figures,
+                                tables: store.tables,
+                                formulas: store.formulas)
+      expect(turtle).to include("figure/fig-mixed-reflection")
+      expect(turtle).to include("table/tbl-si-units")
+      expect(turtle).to include("formula/fml-wave-eq")
+    end
+  end
 end


### PR DESCRIPTION
Two related changes from TODO.remaining/00 and /01.

1. **lib/glossarist/rdf.rb** — autoload EmitsExtraTriples and LutamlTurtleTransformExt instead of require_relative. Per the global rule: never require_relative for own library code; define autoloads in the immediate parent namespace file. The prepend fires the first time EmitsExtraTriples is referenced (i.e., when GlossLocalizedConcept includes it during its own autoload), which is before any transform runs.

2. **GlossaryStore integration for dataset-level non-verbal entities** — closes the loop on PR #205 which shipped the RDF building blocks but left callers constructing Figure/Table/Formula instances manually.
   - lib/glossarist/glossary_store.rb — add #figures, #tables, #formulas lazy accessors and a private load_dataset_entities helper that scans {dataset_path}/{subdir}/*.yaml and parses each as the corresponding model. @dataset_path is set in load_directory / load_zip. Absent directories return [].
   - lib/glossarist/cli/export_command.rb — load_concepts uses memoized #store; new #dataset_figures, #dataset_tables, #dataset_formulas. export_turtle and export_jsonld pass entities to transform.
   - lib/glossarist/transforms/concept_to_gloss_transform.rb — to_turtle and to_jsonld now accept optional figures:, tables:, formulas: kwargs. Backward compatible.

End-to-end: load a dataset directory, emit gloss:Figure / gloss:Table / gloss:Formula RDF without manual model construction.

## Test plan

- [x] 6 new specs in glossary_store_spec.rb (NVR loaders round-trip + end-to-end transform emission)
- [x] bundle exec rspec full suite — 1652 examples, 0 failures
- [x] bundle exec rubocop — clean
- [x] No require_relative in lib/ (the only remaining one is in tasks/sync.rake which is rake-task infra, not library code)