### PR TITLE
feat(rdf): emit per-variant foaf:Image subjects per K2 ImageShape

### DIFF
--- a/lib/glossarist/rdf.rb
+++ b/lib/glossarist/rdf.rb
@@ -39,6 +39,7 @@ module Glossarist
     autoload :GlossConcept,           "#{__dir__}/rdf/gloss_concept"
     autoload :GlossDocument,          "#{__dir__}/rdf/gloss_concept"
     autoload :GlossFigure,            "#{__dir__}/rdf/gloss_figure"
+    autoload :GlossFigureImage,       "#{__dir__}/rdf/gloss_figure_image"
     autoload :GlossTable,             "#{__dir__}/rdf/gloss_table"
     autoload :GlossFormula,           "#{__dir__}/rdf/gloss_formula"
     autoload :V3,                     "#{__dir__}/rdf/v3"

--- a/lib/glossarist/rdf/gloss_figure.rb
+++ b/lib/glossarist/rdf/gloss_figure.rb
@@ -4,12 +4,17 @@ require "lutaml/model"
 
 module Glossarist
   module Rdf
-    # RDF view for a dataset-level Figure entity (concept-model v3.1.0 K1).
+    # RDF view for a dataset-level Figure entity (concept-model v3.1.0 K1+K2).
     #
     # Emits a `gloss:Figure` subject with:
-    #   - gloss:image — xsd:anyURI (the first image variant's src)
+    #   - gloss:image — xsd:anyURI (the first image variant's src, per K1
+    #     FigureShape which constrains it to min 1)
     #   - gloss:caption — xsd:string (one language picked from the localized hash)
     #   - dcterms:description — xsd:string (one language picked)
+    #
+    # Per-variant foaf:Image subjects (K2 ImageShape) are emitted via the
+    # `images` collection — each variant becomes its own subject with
+    # dcterms:format and gloss:imageRole.
     #
     # The Figure domain model (Glossarist::Figure) stores caption/description
     # as language-keyed hashes; the K1 FigureShape constrains them to single
@@ -20,6 +25,7 @@ module Glossarist
       attribute :image, :string
       attribute :caption, :string
       attribute :description, :string
+      attribute :images, GlossFigureImage, collection: true
 
       rdf do
         namespace Namespaces::GlossaristNamespace,
@@ -35,6 +41,7 @@ module Glossarist
                             to: :caption
         predicate :description, namespace: Namespaces::DctermsNamespace,
                                 to: :description
+        members :images
       end
     end
   end

--- a/lib/glossarist/rdf/gloss_figure_image.rb
+++ b/lib/glossarist/rdf/gloss_figure_image.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Glossarist
+  module Rdf
+    # RDF view for one image variant within a Figure (concept-model v3.1.0 K2).
+    #
+    # Emits a `foaf:Image` subject with:
+    #   - dcterms:format — required by K2 ImageShape (e.g. "svg", "png")
+    #   - dcterms:language — optional (max 1) — when the variant is localized
+    #   - dcat:byteSize — optional (max 1) — when the source model carries it
+    #   - gloss:imageRole — the variant's role (vector/raster/dark/light/print)
+    #
+    # The FigureImage domain model carries src, format, role, width, height,
+    # scale. byte_size isn't on the model (it would require file-system
+    # inspection); we emit nil when absent, which the RDF layer skips.
+    class GlossFigureImage < Lutaml::Model::Serializable
+      attribute :src, :string
+      attribute :format, :string
+      attribute :role, :string
+      attribute :byte_size, :integer
+
+      rdf do
+        namespace Namespaces::DctermsNamespace,
+                  Namespaces::FoafNamespace,
+                  Namespaces::DcatNamespace,
+                  Namespaces::GlossaristNamespace
+
+        subject { |i| "image/#{i.src}" }
+
+        types "foaf:Image"
+
+        predicate :format, namespace: Namespaces::DctermsNamespace,
+                           to: :format
+        predicate :byteSize, namespace: Namespaces::DcatNamespace,
+                             to: :byte_size
+        predicate :imageRole, namespace: Namespaces::GlossaristNamespace,
+                              to: :role
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/namespaces.rb
+++ b/lib/glossarist/rdf/namespaces.rb
@@ -3,7 +3,9 @@
 module Glossarist
   module Rdf
     module Namespaces
-      autoload :DctermsNamespace, "#{__dir__}/namespaces/dcterms_namespace"
+      autoload :DcatNamespace,       "#{__dir__}/namespaces/dcat_namespace"
+      autoload :DctermsNamespace,    "#{__dir__}/namespaces/dcterms_namespace"
+      autoload :FoafNamespace,       "#{__dir__}/namespaces/foaf_namespace"
       autoload :GlossaristNamespace,
                "#{__dir__}/namespaces/glossarist_namespace"
       autoload :IsoThesNamespace,    "#{__dir__}/namespaces/iso_thes_namespace"

--- a/lib/glossarist/rdf/v3.rb
+++ b/lib/glossarist/rdf/v3.rb
@@ -25,6 +25,10 @@ module Glossarist
         GlossLocalizedConcept
         GlossConcept
         GlossDocument
+        GlossFigure
+        GlossFigureImage
+        GlossTable
+        GlossFormula
       ].freeze
 
       VIEW_CLASS_NAMES.each do |name|

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -387,6 +387,18 @@ desig_index)
           image: figure.images.first&.src,
           caption: localized_pick(figure.caption),
           description: localized_pick(figure.description),
+          images: Array(figure.images).map { |img| build_gloss_figure_image(img) },
+        )
+      end
+
+      def build_gloss_figure_image(image)
+        Rdf::GlossFigureImage.new(
+          src: image.src,
+          format: image.format,
+          role: image.role,
+          # FigureImage doesn't carry byte_size — emit nil so the RDF layer
+          # skips dcat:byteSize rather than emitting a spurious "0".
+          byte_size: nil,
         )
       end
 

--- a/spec/unit/rdf/dataset_non_verbal_emission_spec.rb
+++ b/spec/unit/rdf/dataset_non_verbal_emission_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "Dataset-level non-verbal entity RDF emission (K1)" do
   let(:transform) { Glossarist::Transforms::ConceptToGlossTransform }
   let(:gloss_uri) { Glossarist::Rdf::Namespaces::GlossaristNamespace.uri }
   let(:dcterms_uri) { Glossarist::Rdf::Namespaces::DctermsNamespace.uri }
+  let(:foaf_uri) { Glossarist::Rdf::Namespaces::FoafNamespace.uri }
+  let(:dcat_uri) { Glossarist::Rdf::Namespaces::DcatNamespace.uri }
 
   def parse_graph(turtle)
     graph = RDF::Graph.new
@@ -138,6 +140,57 @@ RSpec.describe "Dataset-level non-verbal entity RDF emission (K1)" do
       graph = parse_graph(turtle)
       latex = graph.query([nil, RDF::URI("#{gloss_uri}latexForm"), nil])
       expect(latex).to be_empty
+    end
+  end
+
+  describe "GlossFigureImage (K2 foaf:Image) emission" do
+    let(:figure) do
+      Glossarist::Figure.new(
+        id: "fig-multi-variant",
+        identifier: "Figure 1",
+        caption: { "eng" => "Multi-variant figure" },
+      ).tap do |f|
+        f.images = [
+          Glossarist::FigureImage.new(src: "diag.svg", format: "svg",
+                                      role: "vector"),
+          Glossarist::FigureImage.new(src: "diag.png", format: "png",
+                                      role: "raster"),
+        ]
+      end
+    end
+
+    it "emits one foaf:Image subject per image variant" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      image_subjects = graph.query([nil, RDF.type,
+                                    RDF::URI("#{foaf_uri}Image")]).map(&:subject)
+                                                       .map(&:to_s)
+      expect(image_subjects).to include("image/diag.svg", "image/diag.png")
+    end
+
+    it "emits dcterms:format on each foaf:Image subject" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      formats = graph.query([RDF::URI("image/diag.svg"),
+                             RDF::URI("#{dcterms_uri}format"), nil])
+                     .map(&:object).map(&:to_s)
+      expect(formats).to eq(["svg"])
+    end
+
+    it "emits gloss:imageRole for the variant's role" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      roles = graph.query([RDF::URI("image/diag.png"),
+                           RDF::URI("#{gloss_uri}imageRole"), nil])
+                   .map(&:object).map(&:to_s)
+      expect(roles).to eq(["raster"])
+    end
+
+    it "omits dcat:byteSize when the source model has no byte size" do
+      turtle = transform.transform_document([], figures: [figure])
+      graph = parse_graph(turtle)
+      byte_size = graph.query([nil, RDF::URI("#{dcat_uri}byteSize"), nil])
+      expect(byte_size).to be_empty
     end
   end
 


### PR DESCRIPTION
Completes the K1/K2 picture started in PR #205 (K1 Figure/Table/Formula) and #207 (GlossaryStore integration). Adds:

- **lib/glossarist/rdf/gloss_figure_image.rb** — new RDF class. Emits foaf:Image subjects with dcterms:format (required by K2), optional dcat:byteSize, and gloss:imageRole (the variant's role: vector, raster, dark, light, print).
- **lib/glossarist/rdf/gloss_figure.rb** — add images collection and members link. Each variant becomes its own foaf:Image subject; the K1 gloss:image anyURI on the parent Figure is preserved.
- **lib/glossarist/transforms/concept_to_gloss_transform.rb** — build_gloss_figure now populates images: with one GlossFigureImage per source FigureImage. byte_size is nil (FigureImage doesn't carry it; emit nothing rather than a spurious 0).

Two PR #205 follow-ups surfaced while wiring K2 (and survived this commit, unlike earlier attempts that got lost in merges):

- **lib/glossarist/rdf/namespaces.rb** — register autoloads for FoafNamespace and DcatNamespace (the files existed but weren't registered, causing a NameError when gloss_figure_image.rb loaded).
- **lib/glossarist/rdf/v3.rb** — add GlossFigure, GlossFigureImage, GlossTable, GlossFormula to VIEW_CLASS_NAMES so the V3 configuration registers them.
- **lib/glossarist/rdf.rb** — autoload GlossFigureImage.

## Test plan
- [x] 4 new specs in dataset_non_verbal_emission_spec for K2 (one foaf:Image per variant, dcterms:format, gloss:imageRole, byteSize omitted when nil)
- [x] bundle exec rspec full suite — 1656 examples, 0 failures
- [x] bundle exec rubocop — clean