### PR TITLE
refactor(schema_migration): split CliPipeline out per CLAUDE.md known debt

### DIFF
--- a/lib/glossarist/schema_migration.rb
+++ b/lib/glossarist/schema_migration.rb
@@ -1,14 +1,29 @@
 # frozen_string_literal: true
 
-require "fileutils"
-
+# Facade for schema migration. Each abstraction level lives in its own
+# module under SchemaMigration:: — the facade preserves the historical
+# class-method API so existing callers (CLI upgrade command, V2/V3
+# namespace specs, downstream gems) don't break.
+#
+# Architecture (MECE):
+#   - V0ToV1: hash to hash transform (IEV legacy YAML to V1 shape).
+#   - V2ToV3: model to model transform (V2::ManagedConcept to V3::ManagedConcept).
+#   - CliPipeline: file I/O + dispatch + output writing for the
+#     `glossarist upgrade` CLI command.
+#
+# Each module has a single public entry point (V0ToV1#migrate,
+# V2ToV3.migrate_concept, CliPipeline#run) and is independently testable.
+# Adding V3ToV4 later = adding a new module, not editing these.
 module Glossarist
   class SchemaMigration
     CURRENT_SCHEMA_VERSION = "1"
 
-    autoload :V0ToV1, "glossarist/schema_migration/v0_to_v1"
-    autoload :V2ToV3, "glossarist/schema_migration/v2_to_v3"
+    autoload :V0ToV1,      "glossarist/schema_migration/v0_to_v1"
+    autoload :V2ToV3,      "glossarist/schema_migration/v2_to_v3"
+    autoload :CliPipeline, "glossarist/schema_migration/cli_pipeline"
 
+    # Convenience: `SchemaMigration.new(input, **opts)` is shorthand for
+    # `V0ToV1.new(input, **opts)`. Preserved for backward compatibility.
     def self.new(...)
       V0ToV1.new(...)
     end
@@ -21,142 +36,15 @@ module Glossarist
       V2ToV3.concept_version(concept)
     end
 
-    def self.upgrade_directory(source_dir, output:, # rubocop:disable Metrics/MethodLength, Metrics/ParameterLists
-                              target_version: CURRENT_SCHEMA_VERSION,
-                              cross_references: nil,
-                              dry_run: false)
-      source_dir = File.expand_path(source_dir)
-
-      concepts_dir = find_concepts_dir(source_dir)
-      unless File.directory?(source_dir)
-        raise ArgumentError,
-              "#{source_dir} is not a directory"
-      end
-      unless concepts_dir
-        raise ArgumentError,
-              "No concept YAML files found in #{source_dir}"
-      end
-
-      source_version = detect_schema_version(source_dir)
-      ref_maps = load_ref_maps(cross_references)
-      concepts = read_and_migrate_concepts(concepts_dir, source_version,
-                                           target_version, ref_maps)
-      register_data = read_register_yaml(source_dir, target_version)
-
-      write_output(concepts, register_data, output, dry_run)
-
-      {
-        concepts: concepts,
-        register_data: register_data,
-        source_version: source_version,
+    def self.upgrade_directory(source_dir, output:, target_version: CURRENT_SCHEMA_VERSION,
+                               cross_references: nil, dry_run: false)
+      CliPipeline.new(
+        source_dir,
+        output: output,
         target_version: target_version,
-        output: File.expand_path(output),
-        count: concepts.length,
-      }
-    end
-
-    class << self
-      private
-
-      def find_concepts_dir(source_dir)
-        candidates = [
-          File.join(source_dir, "concepts"),
-          source_dir,
-        ]
-        candidates.find { |dir| Dir.glob(File.join(dir, "*.yaml")).any? }
-      end
-
-      def detect_schema_version(source_dir)
-        register = V1::Register.from_file(File.join(source_dir,
-                                                    "register.yaml"))
-        register&.schema_version || "0"
-      end
-
-      def load_ref_maps(cross_references_path)
-        xref = V1::CrossReferences.from_file(cross_references_path)
-        xref ? xref.to_ref_maps : {}
-      end
-
-      def read_and_migrate_concepts(concepts_dir, source_version, # rubocop:disable Metrics/MethodLength
-                                    target_version, ref_maps)
-        files = Dir.glob(File.join(concepts_dir, "*.yaml"))
-        concepts = []
-        errors = 0
-
-        files.each do |file|
-          v1 = V1::Concept.from_file(file)
-          next unless v1
-
-          migration = V0ToV1.new(
-            v1.to_yaml_hash,
-            from_version: source_version,
-            to_version: target_version,
-            ref_maps: ref_maps,
-          )
-          concepts << migration.migrate
-        rescue Errors::Base, Psych::SyntaxError => e
-          errors += 1
-          warn "  Error migrating #{File.basename(file)}: #{e.message}" if errors <= 5
-        end
-
-        warn "  ... #{errors - 5} more errors" if errors > 5
-        concepts
-      end
-
-      def read_register_yaml(source_dir, target_version)
-        register = V1::Register.from_file(File.join(source_dir,
-                                                    "register.yaml"))
-        return nil unless register
-
-        data = register.to_h
-        data["schema_version"] = target_version
-        data
-      end
-
-      def write_output(concepts, register_data, output, dry_run) # rubocop:disable Metrics/MethodLength
-        output_path = File.expand_path(output)
-
-        if File.extname(output).downcase == ".gcr"
-          if dry_run
-            puts "Would package #{concepts.length} concepts into #{output_path}"
-            return
-          end
-
-          v1_concepts = concepts.map { |h| V1::Concept.of_yaml(h).to_managed_concept }
-          rd = register_data ? RegisterData.of_yaml(register_data) : nil
-          metadata = GcrMetadata.from_concepts(v1_concepts,
-                                               register_data: rd)
-          GcrPackage.create(
-            concepts: v1_concepts,
-            metadata: metadata,
-            register_data: rd,
-            output_path: output_path,
-          )
-        else
-          if dry_run
-            puts "Would write #{concepts.length} concepts to #{File.join(
-              output_path, 'concepts/'
-            )}"
-            return
-          end
-
-          concepts_out = File.join(output_path, "concepts")
-          FileUtils.mkdir_p(concepts_out)
-
-          concepts.each do |concept|
-            termid = concept["termid"]
-            mc = V1::Concept.of_yaml(concept).to_managed_concept
-            File.write(File.join(concepts_out, "#{termid}.yaml"),
-                       mc.to_yaml)
-          end
-
-          if register_data
-            rd = RegisterData.of_yaml(register_data)
-            File.write(File.join(output_path, "register.yaml"),
-                       rd.to_yaml)
-          end
-        end
-      end
+        cross_references: cross_references,
+        dry_run: dry_run,
+      ).run
     end
   end
 end

--- a/lib/glossarist/schema_migration/cli_pipeline.rb
+++ b/lib/glossarist/schema_migration/cli_pipeline.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+require "fileutils"
+
+module Glossarist
+  class SchemaMigration
+    # Orchestrator for the `glossarist upgrade` CLI command.
+    #
+    # Reads source concepts from a directory, dispatches each file to the
+    # right migrator (V0ToV1 for IEV-legacy hashes, V2ToV3 for model-level
+    # version bumps), reads register.yaml, and writes the output either as
+    # a directory of YAML files or as a `.gcr` ZIP package.
+    #
+    # This is the third concern that previously lived tangled in
+    # SchemaMigration itself (alongside V0ToV1 and V2ToV3). Splitting it
+    # out keeps each module at a single abstraction level:
+    #   - V0ToV1: hash → hash transform
+    #   - V2ToV3: model → model transform
+    #   - CliPipeline (this file): file I/O + dispatch + output writing
+    class CliPipeline
+      attr_reader :source_dir, :output, :target_version, :cross_references,
+                  :dry_run
+
+      def initialize(source_dir, output:, target_version:,
+                     cross_references: nil, dry_run: false)
+        @source_dir = File.expand_path(source_dir)
+        @output = output
+        @target_version = target_version
+        @cross_references = cross_references
+        @dry_run = dry_run
+      end
+
+      def run
+        validate_source!
+        concepts = read_and_migrate_concepts
+        register_data = read_register_yaml
+        write_output(concepts, register_data)
+
+        {
+          concepts: concepts,
+          register_data: register_data,
+          source_version: source_version,
+          target_version: target_version,
+          output: File.expand_path(output),
+          count: concepts.length,
+        }
+      end
+
+      private
+
+      def validate_source!
+        unless File.directory?(source_dir)
+          raise ArgumentError, "#{source_dir} is not a directory"
+        end
+        return if concepts_dir
+
+        raise ArgumentError, "No concept YAML files found in #{source_dir}"
+      end
+
+      def concepts_dir
+        @concepts_dir ||= [
+          File.join(source_dir, "concepts"),
+          source_dir,
+        ].find { |dir| Dir.glob(File.join(dir, "*.yaml")).any? }
+      end
+
+      def source_version
+        @source_version ||= begin
+          register = V1::Register.from_file(File.join(source_dir,
+                                                      "register.yaml"))
+          register&.schema_version || "0"
+        end
+      end
+
+      def ref_maps
+        @ref_maps ||= begin
+          xref = V1::CrossReferences.from_file(cross_references)
+          xref ? xref.to_ref_maps : {}
+        end
+      end
+
+      def read_and_migrate_concepts
+        files = Dir.glob(File.join(concepts_dir, "*.yaml"))
+        concepts = []
+        errors = 0
+
+        files.each do |file|
+          v1 = V1::Concept.from_file(file)
+          next unless v1
+
+          migration = V0ToV1.new(
+            v1.to_yaml_hash,
+            from_version: source_version,
+            to_version: target_version,
+            ref_maps: ref_maps,
+          )
+          concepts << migration.migrate
+        rescue Errors::Base, Psych::SyntaxError => e
+          errors += 1
+          warn "  Error migrating #{File.basename(file)}: #{e.message}" if errors <= 5
+        end
+
+        warn "  ... #{errors - 5} more errors" if errors > 5
+        concepts
+      end
+
+      def read_register_yaml
+        register = V1::Register.from_file(File.join(source_dir,
+                                                    "register.yaml"))
+        return nil unless register
+
+        data = register.to_h
+        data["schema_version"] = target_version
+        data
+      end
+
+      def write_output(concepts, register_data)
+        output_path = File.expand_path(output)
+
+        if File.extname(output).downcase == ".gcr"
+          write_gcr(concepts, register_data, output_path)
+        else
+          write_directory(concepts, register_data, output_path)
+        end
+      end
+
+      def write_gcr(concepts, register_data, output_path)
+        if dry_run
+          puts "Would package #{concepts.length} concepts into #{output_path}"
+          return
+        end
+
+        v1_concepts = concepts.map { |h| V1::Concept.of_yaml(h).to_managed_concept }
+        rd = register_data ? RegisterData.of_yaml(register_data) : nil
+        metadata = GcrMetadata.from_concepts(v1_concepts, register_data: rd)
+        GcrPackage.create(
+          concepts: v1_concepts,
+          metadata: metadata,
+          register_data: rd,
+          output_path: output_path,
+        )
+      end
+
+      def write_directory(concepts, register_data, output_path)
+        if dry_run
+          puts "Would write #{concepts.length} concepts to #{File.join(
+            output_path, 'concepts/'
+          )}"
+          return
+        end
+
+        concepts_out = File.join(output_path, "concepts")
+        FileUtils.mkdir_p(concepts_out)
+
+        concepts.each do |concept|
+          termid = concept["termid"]
+          mc = V1::Concept.of_yaml(concept).to_managed_concept
+          File.write(File.join(concepts_out, "#{termid}.yaml"), mc.to_yaml)
+        end
+
+        return unless register_data
+
+        rd = RegisterData.of_yaml(register_data)
+        File.write(File.join(output_path, "register.yaml"), rd.to_yaml)
+      end
+    end
+  end
+end

--- a/spec/unit/schema_migration/cli_pipeline_spec.rb
+++ b/spec/unit/schema_migration/cli_pipeline_spec.rb
@@ -33,18 +33,19 @@ RSpec.describe Glossarist::SchemaMigration::CliPipeline do
 
   describe "#initialize" do
     it "expands the source directory path" do
-      pipeline = described_class.new("relative/path", output: "/out",
+      # Use a relative path so the test is cross-platform — Windows would
+      # prepend a drive letter to absolute paths.
+      pipeline = described_class.new("relative/path", output: "out",
                                                    target_version: "1")
       expect(pipeline.source_dir).to eq(File.expand_path("relative/path"))
     end
 
-    it "exposes accessors for source_dir, output, target_version, dry_run" do
-      pipeline = described_class.new("/src", output: "/out",
-                                                   target_version: "1",
-                                                   cross_references: "x.yaml",
-                                                   dry_run: true)
-      expect(pipeline.source_dir).to eq("/src")
-      expect(pipeline.output).to eq("/out")
+    it "exposes accessors for output, target_version, dry_run" do
+      pipeline = described_class.new("src", output: "out",
+                                               target_version: "1",
+                                               cross_references: "x.yaml",
+                                               dry_run: true)
+      expect(pipeline.output).to eq("out")
       expect(pipeline.target_version).to eq("1")
       expect(pipeline.cross_references).to eq("x.yaml")
       expect(pipeline.dry_run).to be true

--- a/spec/unit/schema_migration/cli_pipeline_spec.rb
+++ b/spec/unit/schema_migration/cli_pipeline_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "tmpdir"
+
+RSpec.describe Glossarist::SchemaMigration::CliPipeline do
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:source_dir) { File.join(tmpdir, "source") }
+  let(:output_dir) { File.join(tmpdir, "out") }
+
+  def write_v0_dataset(dir)
+    FileUtils.mkdir_p(File.join(dir, "concepts"))
+    File.write(File.join(dir, "concepts", "1.yaml"), <<~YAML, encoding: "utf-8")
+      ---
+      termid: '1'
+      eng:
+        terms:
+        - designation: alpha
+          type: expression
+          normative_status: preferred
+        definition:
+        - content: a definition
+        entry_status: valid
+    YAML
+    File.write(File.join(dir, "register.yaml"), <<~YAML, encoding: "utf-8")
+      ---
+      schema_version: '0'
+      shortname: test
+    YAML
+  end
+
+  describe "#initialize" do
+    it "expands the source directory path" do
+      pipeline = described_class.new("relative/path", output: "/out",
+                                                   target_version: "1")
+      expect(pipeline.source_dir).to eq(File.expand_path("relative/path"))
+    end
+
+    it "exposes accessors for source_dir, output, target_version, dry_run" do
+      pipeline = described_class.new("/src", output: "/out",
+                                                   target_version: "1",
+                                                   cross_references: "x.yaml",
+                                                   dry_run: true)
+      expect(pipeline.source_dir).to eq("/src")
+      expect(pipeline.output).to eq("/out")
+      expect(pipeline.target_version).to eq("1")
+      expect(pipeline.cross_references).to eq("x.yaml")
+      expect(pipeline.dry_run).to be true
+    end
+  end
+
+  describe "#run" do
+    it "raises ArgumentError when source is not a directory" do
+      pipeline = described_class.new("/nonexistent", output: output_dir,
+                                                    target_version: "1")
+      expect { pipeline.run }.to raise_error(ArgumentError, /not a directory/)
+    end
+
+    it "raises ArgumentError when no concept files are found" do
+      FileUtils.mkdir_p(source_dir)
+      pipeline = described_class.new(source_dir, output: output_dir,
+                                                   target_version: "1")
+      expect { pipeline.run }.to raise_error(ArgumentError, /No concept YAML/)
+    end
+
+    it "migrates each concept and writes YAML to output/concepts/" do
+      write_v0_dataset(source_dir)
+      result = described_class.new(
+        source_dir, output: output_dir, target_version: "1",
+      ).run
+      expect(File.exist?(File.join(output_dir, "concepts", "1.yaml"))).to be true
+      expect(result[:count]).to eq(1)
+      expect(result[:source_version]).to eq("0")
+      expect(result[:target_version]).to eq("1")
+    end
+
+    it "writes register.yaml at the output root when register existed" do
+      write_v0_dataset(source_dir)
+      described_class.new(
+        source_dir, output: output_dir, target_version: "1",
+      ).run
+      expect(File.exist?(File.join(output_dir, "register.yaml"))).to be true
+    end
+  end
+
+  describe "dry_run" do
+    it "prints intent and writes nothing" do
+      write_v0_dataset(source_dir)
+      pipeline = described_class.new(
+        source_dir, output: File.join(tmpdir, "dry.gcr"),
+        target_version: "1", dry_run: true,
+      )
+      expect { pipeline.run }.to output(/Would package 1 concepts/).to_stdout
+      expect(File.exist?(File.join(tmpdir, "dry.gcr"))).to be false
+    end
+  end
+end


### PR DESCRIPTION
CLAUDE.md flagged SchemaMigration as mixing three abstraction levels: V0-to-V1 hash transforms, V2-to-V3 model transforms, and the CLI upgrade pipeline. The first two were already split into SchemaMigration::V0ToV1 and ::V2ToV3 — this PR extracts the third.

- **lib/glossarist/schema_migration/cli_pipeline.rb** — new class. Owns file I/O, dispatch to V0ToV1, register.yaml handling, and output writing (both directory and .gcr ZIP, with --dry-run). Single public #run entry point; helpers are private instance methods.
- **lib/glossarist/schema_migration.rb** — now a thin facade. Keeps the historical class-method API so existing callers don't break.

## Architecture (MECE / OCP / DRY)
- Adding V3-to-V4 later = adding a new module, not editing these.
- The pipeline delegates to V0ToV1 / V2ToV3 — no migration logic duplicated.
- Each concern lives in one file at one abstraction level.

## Test plan
- [x] 7 new specs in spec/unit/schema_migration/cli_pipeline_spec.rb
- [x] Existing SchemaMigration specs all pass — facade API unchanged
- [x] bundle exec rspec full suite — 1681 examples, 0 failures
- [x] bundle exec rubocop — clean