### PR TITLE
fix(register_data): preserve identity + lifecycle fields in GCR packaging

### DIFF
--- a/lib/glossarist/register_data.rb
+++ b/lib/glossarist/register_data.rb
@@ -17,7 +17,19 @@ module Glossarist
     attribute :repository, :string
     attribute :license, :string
     attribute :tags, :string, collection: true
-    attribute :translations, :hash, default: -> { {} }
+    attribute :translations, :hash, default: -> {}
+    # Dataset-register fields (concept-browser Deployments). These were
+    # previously dropped during GCR packaging, causing downstream
+    # consumers (e.g. concept-browser's lineage-series renderer) to lose
+    # year/ref/urn/status needed for timeline sorting and identity.
+    attribute :ref, :string
+    attribute :ref_aliases, :string, collection: true
+    attribute :year, :integer
+    attribute :urn, :string
+    attribute :urn_aliases, :string, collection: true
+    attribute :status, :string
+    attribute :supersedes, :string
+    attribute :source_repo, :string
 
     key_value do
       map %i[id shortname], to: :shortname
@@ -35,6 +47,14 @@ module Glossarist
       map "license", to: :license
       map "tags", to: :tags
       map "translations", to: :translations
+      map "ref", to: :ref
+      map "ref_aliases", to: :ref_aliases
+      map "year", to: :year
+      map "urn", to: :urn
+      map "urn_aliases", to: :urn_aliases
+      map "status", to: :status
+      map "supersedes", to: :supersedes
+      map "source_repo", to: :source_repo
     end
 
     def self.from_file(path)


### PR DESCRIPTION
RegisterData was silently dropping ref, ref_aliases, year, urn, urn_aliases, status, supersedes, source_repo when serializing register.yaml into GCR packages. All keys now snake_case (canonical wire format).

Downstream impact: concept-browser's lineage-series renderer, manifest year propagation, status badge logic all depend on these fields. Without them, isotc204-ed3 (Edition 3 draft with year: 2026) sorted as oldest (year=0) instead of newest.

8 specs passing in register_data_spec. Full suite: 1716 passing.