### PR TITLE
fix(register_data): drop name/description, stop coercing localized hashes to strings

### DIFF
--- a/lib/glossarist/gcr_metadata.rb
+++ b/lib/glossarist/gcr_metadata.rb
@@ -52,8 +52,8 @@ module Glossarist
       new(
         shortname: options[:shortname] || rd&.shortname,
         version: options[:version] || rd&.version,
-        title: options[:title] || rd&.name,
-        description: options[:description] || rd&.description,
+        title: options[:title],
+        description: options[:description],
         owner: options[:owner],
         tags: options[:tags] || [],
         concept_count: concepts.length,

--- a/lib/glossarist/register_data.rb
+++ b/lib/glossarist/register_data.rb
@@ -4,8 +4,6 @@ module Glossarist
   class RegisterData < Lutaml::Model::Serializable
     attribute :key, :string, default: -> { "register" }
     attribute :shortname, :string
-    attribute :name, :string
-    attribute :description, :string
     attribute :schema_version, :string
     attribute :version, :string
     attribute :owner, :string
@@ -18,10 +16,10 @@ module Glossarist
     attribute :license, :string
     attribute :tags, :string, collection: true
     attribute :translations, :hash, default: -> {}
-    # Dataset-register fields (concept-browser Deployments). These were
-    # previously dropped during GCR packaging, causing downstream
-    # consumers (e.g. concept-browser's lineage-series renderer) to lose
-    # year/ref/urn/status needed for timeline sorting and identity.
+
+    # Identity and lifecycle fields. These MUST round-trip through GCR
+    # packaging so consumers (concept-browser's lineage-series renderer,
+    # manifest year propagation, status badge logic) see them.
     attribute :ref, :string
     attribute :ref_aliases, :string, collection: true
     attribute :year, :integer
@@ -31,10 +29,15 @@ module Glossarist
     attribute :supersedes, :string
     attribute :source_repo, :string
 
+    # Display name + description are deliberately NOT serialized in the GCR.
+    # They are localized (hash) values in source register.yaml and the gem
+    # can't coerce them to a stable wire form without lossy .to_s coercion.
+    # Display metadata belongs in the deployment's site-config.yml, which
+    # is the SSOT for per-dataset title/description overrides. The GCR
+    # carries identity (ref, urn, year, status) only.
+
     key_value do
       map %i[id shortname], to: :shortname
-      map "name", to: :name
-      map "description", to: :description
       map "schema_version", to: :schema_version
       map "version", to: :version
       map "owner", to: :owner
@@ -47,6 +50,7 @@ module Glossarist
       map "license", to: :license
       map "tags", to: :tags
       map "translations", to: :translations
+
       map "ref", to: :ref
       map "ref_aliases", to: :ref_aliases
       map "year", to: :year

--- a/spec/unit/gcr_metadata_spec.rb
+++ b/spec/unit/gcr_metadata_spec.rb
@@ -39,13 +39,12 @@ RSpec.describe Glossarist::GcrMetadata do
       expect(metadata.statistics.concepts_with_sources).to eq(1)
     end
 
-    it "uses register data for title/description" do
-      register = Glossarist::RegisterData.new(
-        name: "My Dataset",
-        description: "A dataset",
-      )
+    it "uses options for title/description when provided" do
       metadata = described_class.from_concepts(concepts,
-                                               register_data: register)
+                                               options: {
+                                                 title: "My Dataset",
+                                                 description: "A dataset",
+                                               })
 
       expect(metadata.title).to eq("My Dataset")
       expect(metadata.description).to eq("A dataset")

--- a/spec/unit/gcr_package_spec.rb
+++ b/spec/unit/gcr_package_spec.rb
@@ -91,13 +91,14 @@ RSpec.describe Glossarist::GcrPackage do
     end
 
     it "includes register.yaml when provided" do
-      register = { "name" => "Test", "schema_version" => "1" }
+      register = { "shortname" => "test", "schema_version" => "1", "year" => 2024 }
       create_test_gcr(register: register)
 
       Zip::File.open(gcr_path) do |zf|
         expect(zf.find_entry("register.yaml")).not_to be_nil
         rd = Glossarist::RegisterData.from_yaml(zf.find_entry("register.yaml").get_input_stream.read)
-        expect(rd.name).to eq("Test")
+        expect(rd.shortname).to eq("test")
+        expect(rd.year).to eq(2024)
       end
     end
   end

--- a/spec/unit/glossary_store_spec.rb
+++ b/spec/unit/glossary_store_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe Glossarist::GlossaryStore do
                encoding: "utf-8")
 
     File.write(File.join(dir, "register.yaml"),
-               "---\nname: Test Glossary\nsubregisters:\n  eng:\n",
+               "---\nshortname: test-glossary\nsubregisters:\n  eng:\n",
                encoding: "utf-8")
 
     File.write(File.join(dir, "metadata.yaml"), <<~YAML, encoding: "utf-8")
@@ -118,7 +118,7 @@ RSpec.describe Glossarist::GlossaryStore do
     it "loads register data from register.yaml" do
       store.load_directory(glossary_dir)
       expect(store.register_data).to be_a(Glossarist::RegisterData)
-      expect(store.register_data.name).to eq("Test Glossary")
+      expect(store.register_data.shortname).to eq("test-glossary")
     end
 
     it "loads bibliography from bibliography.yaml" do

--- a/spec/unit/register_data_spec.rb
+++ b/spec/unit/register_data_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe Glossarist::RegisterData do
     let(:yaml) do
       <<~YAML
         ---
-        name: Geolexica for Intelligent Transport Systems
-        description: Vocabulary for ITS
+        shortname: tc204
         subregisters:
           eng:
       YAML
@@ -17,16 +16,64 @@ RSpec.describe Glossarist::RegisterData do
 
     it "parses YAML into typed attributes" do
       rd = described_class.from_yaml(yaml)
-      expect(rd.name).to eq("Geolexica for Intelligent Transport Systems")
-      expect(rd.description).to eq("Vocabulary for ITS")
+      expect(rd.shortname).to eq("tc204")
       expect(rd.subregisters).to eq({ "eng" => nil })
     end
 
     it "round-trips through YAML" do
       rd = described_class.from_yaml(yaml)
       reloaded = described_class.from_yaml(rd.to_yaml)
-      expect(reloaded.name).to eq(rd.name)
-      expect(reloaded.description).to eq(rd.description)
+      expect(reloaded.shortname).to eq(rd.shortname)
+    end
+  end
+
+  describe "identity and lifecycle fields" do
+    let(:yaml) do
+      <<~YAML
+        ---
+        id: isotc204-ed3
+        ref: ISO 14812 (Edition 3, draft)
+        year: 2026
+        urn: urn:iso:std:iso:14812:ed3
+        status: current
+        supersedes: isotc204-2025
+        source_repo: https://github.com/ISO-TC204/iso14812
+        ref_aliases:
+          - ISO 14812 Ed3
+        urn_aliases:
+          - urn:iso:std:iso:14812:ed3*
+      YAML
+    end
+
+    it "preserves all fields through round-trip" do
+      rd = described_class.from_yaml(yaml)
+      expect(rd.ref).to eq("ISO 14812 (Edition 3, draft)")
+      expect(rd.year).to eq(2026)
+      expect(rd.urn).to eq("urn:iso:std:iso:14812:ed3")
+      expect(rd.status).to eq("current")
+      expect(rd.supersedes).to eq("isotc204-2025")
+      expect(rd.source_repo).to eq("https://github.com/ISO-TC204/iso14812")
+      expect(rd.ref_aliases).to eq(["ISO 14812 Ed3"])
+      expect(rd.urn_aliases).to eq(["urn:iso:std:iso:14812:ed3*"])
+    end
+
+    it "does not coerce localized name/description hashes to strings" do
+      # Source register.yaml may carry name: as a localized hash. The gem
+      # must NOT serialize this — it would produce lossy .to_s coercion.
+      # Display metadata belongs in the deployment's site-config.yml.
+      yaml_with_localized_name = <<~YAML
+        ---
+        id: test
+        name:
+          eng: Test Vocabulary
+        description:
+          eng: A test.
+        year: 2024
+      YAML
+      rd = described_class.from_yaml(yaml_with_localized_name)
+      reloaded = described_class.from_yaml(rd.to_yaml)
+      expect(reloaded.year).to eq(2024)
+      expect(reloaded.to_yaml).not_to include('{"eng"=>')
     end
   end
 
@@ -48,10 +95,10 @@ RSpec.describe Glossarist::RegisterData do
 
     it "loads from a YAML file" do
       path = File.join(tmpdir, "register.yaml")
-      File.write(path, "---\nname: Test\nshortname: test\n")
+      File.write(path, "---\nshortname: test\nyear: 2024\n")
       rd = described_class.from_file(path)
-      expect(rd.name).to eq("Test")
       expect(rd.shortname).to eq("test")
+      expect(rd.year).to eq(2024)
     end
 
     it "returns nil for missing file" do
@@ -64,7 +111,7 @@ RSpec.describe Glossarist::RegisterData do
       path = File.expand_path("../../isotc204-glossary/register.yaml", __dir__)
       skip "isotc204 fixture not found" unless File.exist?(path)
       rd = described_class.from_file(path)
-      expect(rd.name).to include("Intelligent Transport Systems")
+      expect(rd.shortname).to eq("isotc204")
       expect(rd.subregisters).to include("eng")
     end
 
@@ -72,7 +119,7 @@ RSpec.describe Glossarist::RegisterData do
       path = File.expand_path("../../isotc211-glossary/register.yaml", __dir__)
       skip "isotc211 fixture not found" unless File.exist?(path)
       rd = described_class.from_file(path)
-      expect(rd.name).to include("ISO/TC 211")
+      expect(rd.shortname).to eq("isotc211")
       expect(rd.subregisters.keys.length).to be >= 10
     end
   end


### PR DESCRIPTION
RegisterData.name was typed :string but source register.yaml uses localized hash form (name: {eng: '...'}). The :string coercion produced Ruby hash inspect strings in the GCR. concept-browser's sidebar then displayed them verbatim.

Fix: remove name + description from RegisterData. Display metadata belongs in deployment site-config.yml, not in the data package. GcrMetadata title now requires options[:title] (callers already pass --title).

1718 specs passing.