### PR TITLE
feat: add sourced_from to ConceptSource for provenance chains

### DIFF
--- a/lib/glossarist/concept_source.rb
+++ b/lib/glossarist/concept_source.rb
@@ -7,6 +7,7 @@ module Glossarist
               values: Glossarist::GlossaryDefinition::CONCEPT_SOURCE_TYPES
     attribute :origin, Citation
     attribute :modification, :string
+    attribute :sourced_from, Citation, collection: true
 
     key_value do
       map :id, to: :id
@@ -14,6 +15,7 @@ module Glossarist
       map :status, to: :status
       map :type, to: :type
       map :modification, to: :modification
+      map :sourced_from, to: :sourced_from
     end
   end
 end

--- a/lib/glossarist/rdf/gloss_concept_source.rb
+++ b/lib/glossarist/rdf/gloss_concept_source.rb
@@ -9,6 +9,7 @@ module Glossarist
       attribute :type, :string
       attribute :modification, :string
       attribute :origin, GlossCitation
+      attribute :sourced_from, GlossCitation, collection: true
 
       rdf do
         namespace Namespaces::GlossaristNamespace
@@ -25,6 +26,7 @@ module Glossarist
                                  to: :modification
 
         members :origin, link: "gloss:sourceOrigin"
+        members :sourced_from, link: "gloss:sourcedFrom"
       end
 
       def self.deterministic_id(source)
@@ -32,6 +34,9 @@ module Glossarist
         origin = source.origin
         if origin
           parts << origin.source << origin.id << origin.version << origin.link
+        end
+        Array(source.sourced_from).each do |sf|
+          parts << sf&.source << sf&.id << sf&.version << sf&.link
         end
         Digest::MD5.hexdigest(parts.compact.join("|"))[0..11]
       end

--- a/lib/glossarist/v2/concept_source.rb
+++ b/lib/glossarist/v2/concept_source.rb
@@ -4,12 +4,14 @@ module Glossarist
   module V2
     class ConceptSource < Glossarist::ConceptSource
       attribute :origin, V2::Citation
+      attribute :sourced_from, V2::Citation, collection: true
 
       key_value do
         map :origin, to: :origin
         map :status, to: :status
         map :type, to: :type
         map :modification, to: :modification
+        map :sourced_from, to: :sourced_from
       end
     end
   end

--- a/lib/glossarist/v3/concept_source.rb
+++ b/lib/glossarist/v3/concept_source.rb
@@ -4,12 +4,14 @@ module Glossarist
   module V3
     class ConceptSource < Glossarist::ConceptSource
       attribute :origin, V3::Citation
+      attribute :sourced_from, V3::Citation, collection: true
 
       key_value do
         map :origin, to: :origin
         map :status, to: :status
         map :type, to: :type
         map :modification, to: :modification
+        map :sourced_from, to: :sourced_from
       end
     end
   end

--- a/spec/unit/concept_source_spec.rb
+++ b/spec/unit/concept_source_spec.rb
@@ -85,4 +85,83 @@ RSpec.describe Glossarist::ConceptSource do
       expect(subject.status).to eq("identical")
     end
   end
+
+  describe "#sourced_from" do
+    it "defaults to nil when not provided" do
+      source = described_class.new(type: "authoritative")
+      expect(source.sourced_from).to be_nil
+    end
+
+    it "round-trips through to_yaml and from_yaml" do
+      source = described_class.new(
+        type: "lineage",
+        status: "identical",
+        origin: Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(
+          source: "OIML", id: "G 18", version: "2010",
+        )),
+        sourced_from: [
+          Glossarist::Citation.new(ref: Glossarist::Citation::Ref.new(
+            source: "OIML", id: "B 3", version: "2003",
+          )),
+        ],
+      )
+      yaml = source.to_yaml
+      restored = described_class.from_yaml(yaml)
+      expect(restored.sourced_from.length).to eq(1)
+      expect(restored.sourced_from.first.ref.source).to eq("OIML")
+      expect(restored.sourced_from.first.ref.id).to eq("B 3")
+    end
+
+    it "round-trips multiple sourced_from entries" do
+      yaml = <<~YAML
+        ---
+        type: lineage
+        status: modified
+        modification: merged definitions from B 3 and B 4
+        origin:
+          ref:
+            source: OIML
+            id: 'G 18'
+            version: '2010'
+        sourced_from:
+        - ref:
+            source: OIML
+            id: 'B 3'
+            version: '2003'
+        - ref:
+            source: OIML
+            id: 'B 4'
+            version: '2005'
+      YAML
+      restored = described_class.from_yaml(yaml)
+      expect(restored.sourced_from.length).to eq(2)
+      expect(restored.sourced_from[0].ref.id).to eq("B 3")
+      expect(restored.sourced_from[1].ref.id).to eq("B 4")
+    end
+
+    it "preserves locality in sourced_from entries" do
+      yaml = <<~YAML
+        ---
+        type: lineage
+        status: identical
+        origin:
+          ref:
+            source: OIML
+            id: 'G 18'
+            version: '2010'
+        sourced_from:
+        - ref:
+            source: OIML
+            id: 'V 1'
+            version: '2000'
+          locality:
+            type: clause
+            reference_from: '3.1'
+      YAML
+      restored = described_class.from_yaml(yaml)
+      expect(restored.sourced_from.length).to eq(1)
+      expect(restored.sourced_from.first.locality.type).to eq("clause")
+      expect(restored.sourced_from.first.locality.reference_from).to eq("3.1")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Adds `sourced_from` field to `ConceptSource` as a collection of `Citation` objects, enabling explicit provenance chains. A lineage source can declare which upstream documents it was itself sourced from.

- Base `ConceptSource`: `attribute :sourced_from, Citation, collection: true`
- V2/V3 overrides use version-specific `Citation` class
- RDF emitter includes `sourced_from` in deterministic_id computation
- 4 new specs: nil default, round-trip, multiple entries, locality preservation

## Test plan

- [x] `bundle exec rspec spec/unit/concept_source_spec.rb` — 39 examples, 0 failures
- [x] `bundle exec rspec spec/unit/` — 1707 examples, 0 failures