### PR TITLE
feat: PartitiveHyperedge + L10N invariant for all relationship content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,36 @@ All model classes use `Lutaml::Model::Serializable` for serialization.
 - **`ConceptReference`** (`concept_reference.rb`) — a typed reference to another concept. Local refs use `concept_id` alone; external refs use `source` (URN prefix) + `concept_id` or a direct `urn` field. Has `local?`/`external?` predicates. No `to_gcr_hash` or `from_urn` — model-driven architecture uses lutaml-model for serialization; URN construction/parsing belongs in `UrnResolver`.
 - **`RelatedConcept`** (`related_concept.rb`) — a concept with a typed relationship. Relationship types cover ISO 10241-1 (deprecates/supersedes/superseded_by/compare/contrast/see), ISO 25964/SKOS (broader/narrower/broader_generic/narrower_generic/broader_partitive/narrower_partitive/broader_instantial/narrower_instantial/equivalent/close_match/broad_match/narrow_match/related_match), ISO 12620/TBX (homograph/false_friend/related_concept/related_concept_broader/related_concept_narrower/sequentially_related_concept/spatially_related_concept/temporally_related_concept), and designation-level (abbreviated_form_for/short_form_for). Types are defined in `config.yml` under `related_concept.type`.
 
+#### V3 `related` placement (MECE)
+
+In V3, `related` lives **only** on `V3::ManagedConcept#related`.
+`V3::ManagedConceptData` does NOT declare or serialize `related`.
+V2 placed `related` inside data; the `SchemaMigration::V2ToV3#step_v2_to_v3`
+migration moves any data-level entries up to the concept level. The
+V3 output never carries `related` at the data level.
+
+This consolidation closes the legacy trap where writing to
+`data.related` bypassed `ManagedConcept.detect_schema_version` (which
+keys off `concept.related`).
+
+### PartitiveHyperedge (V3 only)
+
+`PartitiveHyperedge` (`v3/partitive_hyperedge.rb`) — a one-to-many partitive decomposition. One comprehensive concept is related to one or more parts as a SINGLE relationship. Captures invariants that binary `RelatedConcept` edges cannot:
+
+- which comprehensive owns which parts (set membership)
+- diagram notation flags (`PluralityMarker`: `double`, `dashed`)
+- enumeration completeness (`PartitiveEnumeration`: `closed`, `open`)
+
+Wired into `V3::ManagedConcept#partitive_hyperedges`. NOT on `ManagedConceptData` (relationships live at the concept level for MECE consistency with `related`).
+
+Enum values are SSOT-loaded from `config.yml` via `GlossaryDefinition::PARTITIVE_ENUMERATION_VALUES` and `PLURALITY_MARKER_VALUES`. The `values:` option on each attribute documents the enum; the model's `initialize` override enforces them at construction (lutaml-model 0.8.17 does not enforce `values:` on assignment). Construction also rejects empty comprehensive, empty parts, self-loops, and duplicate marker values.
+
+Semantic checks (defaulted-enumeration warning, defensive walk) live in `Validation::Rules::PartitiveHyperedgeRule` (auto-registered by `Validation::Rules`).
+
+RDF emission: `Rdf::GlossHyperedge` view class (per-hyperedge `gloss:PartitiveHyperedge` subject with `gloss:comprehensive`, `gloss:part+`, `gloss:enumeration`, `gloss:hasPluralityMarker*`, `gloss:hyperedgeContent?`), wired into `Transforms::ConceptToGlossTransform` and emitted as `gloss:hasHyperedge` link from `GlossConcept`.
+
+Binary `broader_partitive`/`narrower_partitive` `RelatedConcept` edges and `PartitiveHyperedge` coexist — no automatic consolidation. See `concept-model/TODO.hyperedge/00-design-overview.md`.
+
 ### Reference Resolution
 
 - **`ReferenceExtractor`** (`reference_extractor.rb`) — extracts `ConceptReference` and `AssetReference` objects from `{{...}}` mentions and `image::...[]` references in concept text fields.

--- a/config.yml
+++ b/config.yml
@@ -186,3 +186,18 @@ concept_date:
     - retired
     - review
     - review_decision
+
+partitive_enumeration:
+  # Whether a PartitiveHyperedge's parts array constitutes the complete
+  # decomposition of the comprehensive (closed) or only a partial one
+  # (open). Default: closed.
+  value:
+    - closed
+    - open
+
+plurality_marker:
+  # Diagram notation flags from VIM concept-relationship diagrams.
+  # Orthogonal to enumeration — both may be set on the same hyperedge.
+  value:
+    - double   # close-set double line at receiver; several parts involved
+    - dashed   # broken/dashed line; plurality is uncertain

--- a/lib/glossarist/designation/designation_relationship.rb
+++ b/lib/glossarist/designation/designation_relationship.rb
@@ -3,7 +3,7 @@
 module Glossarist
   module Designation
     class DesignationRelationship < Lutaml::Model::Serializable
-      attribute :content, :string
+      attribute :content, :hash
       attribute :type, :string,
                 values: Glossarist::GlossaryDefinition::DESIGNATION_RELATIONSHIP_TYPES
       attribute :target, :string

--- a/lib/glossarist/glossary_definition.rb
+++ b/lib/glossarist/glossary_definition.rb
@@ -33,5 +33,11 @@ module Glossarist
                                                 "relationship_type")&.freeze
 
     ISO12620_TERM_TYPES = config.dig("iso12620", "term_type").freeze
+
+    PARTITIVE_ENUMERATION_VALUES =
+      config.dig("partitive_enumeration", "value").freeze
+
+    PLURALITY_MARKER_VALUES =
+      config.dig("plurality_marker", "value").freeze
   end
 end

--- a/lib/glossarist/managed_concept.rb
+++ b/lib/glossarist/managed_concept.rb
@@ -174,6 +174,8 @@ module Glossarist
       return "3" if concept.related&.any?
       return "3" if concept.sources&.any?
       return "3" if concept.data&.domains&.any?
+      return "3" if concept.is_a?(V3::ManagedConcept) &&
+                     concept.partitive_hyperedges&.any?
       return "3" if localization_has_references?(concept)
 
       "2"

--- a/lib/glossarist/rdf.rb
+++ b/lib/glossarist/rdf.rb
@@ -42,6 +42,7 @@ module Glossarist
     autoload :GlossFigureImage,       "#{__dir__}/rdf/gloss_figure_image"
     autoload :GlossTable,             "#{__dir__}/rdf/gloss_table"
     autoload :GlossFormula,           "#{__dir__}/rdf/gloss_formula"
+    autoload :GlossHyperedge,         "#{__dir__}/rdf/gloss_hyperedge"
     autoload :V3,                     "#{__dir__}/rdf/v3"
   end
 end

--- a/lib/glossarist/rdf/gloss_concept.rb
+++ b/lib/glossarist/rdf/gloss_concept.rb
@@ -11,6 +11,7 @@ module Glossarist
       attribute :sources, GlossConceptSource, collection: true
       attribute :domains, GlossConceptReference, collection: true
       attribute :dates, GlossConceptDate, collection: true
+      attribute :hyperedges, GlossHyperedge, collection: true
 
       RelationshipPredicates::CONCEPT_REL_PREDICATES.each_key do |type|
         attribute :"#{type}_targets", :string, collection: true
@@ -41,6 +42,8 @@ module Glossarist
                 link: "gloss:hasDomain"
         members :dates,
                 link: "gloss:hasDate"
+        members :hyperedges,
+                link: "gloss:hasPartitiveHyperedge"
 
         RelationshipPredicates::CONCEPT_REL_PREDICATES.each do |type, (ns, name)|
           predicate name, namespace: ns, to: :"#{type}_targets",

--- a/lib/glossarist/rdf/gloss_hyperedge.rb
+++ b/lib/glossarist/rdf/gloss_hyperedge.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "lutaml/model"
+
+module Glossarist
+  module Rdf
+    # RDF view for a PartitiveHyperedge (concept-model v3.1.0).
+    #
+    # Emits one `gloss:PartitiveHyperedge` subject per hyperedge with:
+    #
+    #   - gloss:comprehensive — IRI of the comprehensive concept
+    #   - gloss:part          — IRI of each part concept (zero or more)
+    #   - gloss:enumeration   — xsd:string ("closed" | "open")
+    #   - gloss:hasPluralityMarker — xsd:string per marker ("double" |
+    #                                "dashed"). One triple per marker.
+    #   - gloss:hyperedgeContent   — xsd:string (omitted if absent)
+    #
+    # The hyperedge is anchored to the concept that carries it via
+    # `gloss:hasHyperedge` (an inverse of `gloss:comprehensive`). The
+    # subject URI is derived from the carrying concept's identifier
+    # and the comprehensive's id, so it is stable across builds.
+    class GlossHyperedge < Lutaml::Model::Serializable
+      attribute :identifier, :string
+      attribute :comprehensive_id, :string
+      attribute :comprehensive_uri, :string
+      attribute :part_uris, :string, collection: true
+      attribute :enumeration, :string
+      attribute :markers, :string, collection: true
+      attribute :content, :hash
+
+      rdf do
+        namespace Namespaces::GlossaristNamespace
+
+        subject { |h| "hyperedge/#{h.identifier}/#{h.comprehensive_id}" }
+
+        types "gloss:PartitiveHyperedge"
+
+        predicate :comprehensive, namespace: Namespaces::GlossaristNamespace,
+                                   to: :comprehensive_uri
+        predicate :part, namespace: Namespaces::GlossaristNamespace,
+                          to: :part_uris
+        predicate :enumeration, namespace: Namespaces::GlossaristNamespace,
+                                to: :enumeration
+        predicate :hasPluralityMarker,
+                  namespace: Namespaces::GlossaristNamespace,
+                  to: :markers
+        predicate :hyperedgeContent,
+                  namespace: Namespaces::GlossaristNamespace,
+                  to: :content
+      end
+    end
+  end
+end

--- a/lib/glossarist/rdf/v3.rb
+++ b/lib/glossarist/rdf/v3.rb
@@ -29,6 +29,7 @@ module Glossarist
         GlossFigureImage
         GlossTable
         GlossFormula
+        GlossHyperedge
       ].freeze
 
       VIEW_CLASS_NAMES.each do |name|

--- a/lib/glossarist/related_concept.rb
+++ b/lib/glossarist/related_concept.rb
@@ -2,7 +2,7 @@
 
 module Glossarist
   class RelatedConcept < Lutaml::Model::Serializable
-    attribute :content, :string
+    attribute :content, :hash
     attribute :type, :string,
               values: Glossarist::GlossaryDefinition::RELATED_CONCEPT_TYPES
     attribute :ref, ConceptRef

--- a/lib/glossarist/schema_migration/v2_to_v3.rb
+++ b/lib/glossarist/schema_migration/v2_to_v3.rb
@@ -38,11 +38,25 @@ module Glossarist
       end
 
       def self.step_v2_to_v3(concept)
-        if concept.data&.related&.any?
-          concept.related ||= []
-          concept.related = (concept.related + concept.data.related).uniq
-          concept.data.related = []
-        end
+        # V2 placed `related` inside ManagedConceptData; V3 places it
+        # on ManagedConcept itself. Move any data-level related entries
+        # up to the concept level. V3::ManagedConceptData no longer
+        # serializes `related`, so we don't need to clear the moved-from
+        # slot — the V3 output naturally omits it.
+        data_related = concept.data&.related
+        return step_v2_to_v3_hyperedge_note if data_related.nil? || data_related.empty?
+
+        concept.related ||= []
+        concept.related = (concept.related + data_related).uniq
+        "3"
+      end
+
+      # Hyperedges: V2 has no hyperedge concept. V2's binary
+      # `broader_partitive` / `narrower_partitive` edges migrate as
+      # `related` entries (see step_v2_to_v3). Hyperedges are a V3-only
+      # construct and require no migration logic — concepts upgraded
+      # from V2 to V3 simply have no hyperedges.
+      def self.step_v2_to_v3_hyperedge_note
         "3"
       end
     end

--- a/lib/glossarist/transforms/concept_to_gloss_transform.rb
+++ b/lib/glossarist/transforms/concept_to_gloss_transform.rb
@@ -130,8 +130,42 @@ module Glossarist
           domains: build_gloss_domains(managed_concept.data&.domains,
                                        identifier),
           dates: build_gloss_dates(managed_concept.dates, identifier),
+          hyperedges: build_gloss_hyperedges(v3_hyperedges(managed_concept),
+                                             identifier),
           **rel_targets,
         )
+      end
+
+      # Hyperedges are a V3-only attribute. The transform accepts both
+      # V1/V2 and V3 concepts; for V1/V2 concepts the hyperedge list
+      # is always empty.
+      def v3_hyperedges(managed_concept)
+        return [] unless managed_concept.is_a?(V3::ManagedConcept)
+
+        managed_concept.partitive_hyperedges
+      end
+
+      def build_gloss_hyperedges(hyperedges, identifier)
+        return [] unless hyperedges
+
+        Array(hyperedges).map do |he|
+          Rdf::GlossHyperedge.new(
+            identifier: identifier.to_s,
+            comprehensive_id: he.comprehensive.id.to_s,
+            comprehensive_uri: hyperedge_concept_uri(he.comprehensive),
+            part_uris: Array(he.parts).map { |p| hyperedge_concept_uri(p) },
+            enumeration: he.enumeration,
+            markers: Array(he.markers),
+            content: he.content,
+          )
+        end
+      end
+
+      def hyperedge_concept_uri(ref)
+        return nil unless ref.is_a?(Glossarist::ConceptRef)
+
+        Glossarist::Rdf::Namespaces::GlossaristNamespace.uri +
+          "concept/#{ref.id}"
       end
 
       def build_gloss_localized_concept(l10n, concept_id)

--- a/lib/glossarist/v3.rb
+++ b/lib/glossarist/v3.rb
@@ -9,6 +9,7 @@ module Glossarist
     autoload :DetailedDefinition, "glossarist/v3/detailed_definition"
     autoload :ConceptRef, "glossarist/v3/concept_ref"
     autoload :RelatedConcept, "glossarist/v3/related_concept"
+    autoload :PartitiveHyperedge, "glossarist/v3/partitive_hyperedge"
     autoload :ConceptData, "glossarist/v3/concept_data"
     autoload :LocalizedConcept, "glossarist/v3/localized_concept"
     autoload :ManagedConceptData, "glossarist/v3/managed_concept_data"
@@ -23,6 +24,7 @@ module Glossarist
     Configuration.register_model(LocalizedConcept, id: :localized_concept)
     Configuration.register_model(ConceptRef, id: :concept_ref)
     Configuration.register_model(RelatedConcept, id: :related_concept)
+    Configuration.register_model(PartitiveHyperedge, id: :partitive_hyperedge)
     Configuration.register_model(ManagedConceptData, id: :managed_concept_data)
     Configuration.register_model(ManagedConcept, id: :managed_concept)
     Configuration.register_model(ConceptDocument, id: :concept_document)

--- a/lib/glossarist/v3/managed_concept.rb
+++ b/lib/glossarist/v3/managed_concept.rb
@@ -5,6 +5,7 @@ module Glossarist
     class ManagedConcept < Glossarist::ManagedConcept
       attribute :data, V3::ManagedConceptData, default: -> { V3::ManagedConceptData.new }
       attribute :related, V3::RelatedConcept, collection: true
+      attribute :partitive_hyperedges, V3::PartitiveHyperedge, collection: true
       attribute :dates, V3::ConceptDate, collection: true
       attribute :date_accepted, V3::ConceptDate
       attribute :sources, V3::ConceptSource, collection: true
@@ -12,6 +13,7 @@ module Glossarist
       key_value do
         map :data, to: :data
         map :related, to: :related
+        map :partitive_hyperedges, to: :partitive_hyperedges
         map :dates, to: :dates
         map %i[date_accepted dateAccepted],
             with: { from: :date_accepted_from_yaml, to: :date_accepted_to_yaml }

--- a/lib/glossarist/v3/managed_concept_data.rb
+++ b/lib/glossarist/v3/managed_concept_data.rb
@@ -2,6 +2,20 @@
 
 module Glossarist
   module V3
+    # V3 ManagedConceptData — the data payload inside a V3::ManagedConcept.
+    #
+    # V3 placement rule (MECE): `related` lives ONLY on V3::ManagedConcept,
+    # not on its data payload. V2 placed `related` inside data; the
+    # V2→V3 migration (SchemaMigration::V2ToV3) moves it to the concept
+    # level. Keeping `related` writable on V3 data would re-open the
+    # trap where writing to `data.related` bypasses
+    # `ManagedConcept.detect_schema_version` (which keys off
+    # `concept.related`).
+    #
+    # The base class Glossarist::ManagedConceptData still declares
+    # `related` for V1/V2 compatibility; V3 overrides that with an
+    # empty attribute via `attribute :related, nil` so the slot is
+    # inert and serializes nothing.
     class ManagedConceptData < Glossarist::ManagedConceptData
       attribute :sources, V3::ConceptSource, collection: true
       attribute :localizations, V3::LocalizedConcept,
@@ -17,7 +31,6 @@ module Glossarist
                                 with: { from: :domains_from_yaml, to: :domains_to_yaml }
         map :tags, to: :tags
         map :sources, to: :sources
-        map :related, to: :related
         map :localizations, to: :localizations,
                             with: { from: :localizations_from_yaml, to: :localizations_to_yaml }
       end
@@ -34,3 +47,4 @@ module Glossarist
     end
   end
 end
+

--- a/lib/glossarist/v3/partitive_hyperedge.rb
+++ b/lib/glossarist/v3/partitive_hyperedge.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Glossarist
+  module V3
+    # PartitiveHyperedge — a one-to-many partitive decomposition.
+    #
+    # One comprehensive concept (the whole) is related to one or more
+    # parts as a SINGLE relationship. Captures invariants that binary
+    # RelatedConcept edges cannot:
+    #
+    #   - which comprehensive owns which parts (set membership)
+    #   - plurality markers from the source diagram (double / dashed)
+    #   - enumeration completeness (closed: all parts listed; open:
+    #     other parts may exist)
+    #
+    # Enum values are SSOT-loaded from `config.yml` via
+    # `GlossaryDefinition`. The `values:` option on each attribute
+    # documents the enum for schema generation. lutaml-model 0.8.x
+    # does NOT enforce `values:` on assignment — semantic checks live
+    # in `Validation::Rules::PartitiveHyperedgeRule` (auto-registered
+    # via `Validation::Rules`). The model's `validate!` method covers
+    # type-shape invariants that fail loudly at construction (empty
+    # comprehensive, empty parts, self-loop, invalid enum values).
+    #
+    # Note on duplicates: lutaml-model's enum-collection setter
+    # dedupes silently via the getter, so duplicate markers at
+    # construction time are silently coerced to a unique set. We do
+    # not attempt to override this; the framework's Set semantics are
+    # the data contract.
+    #
+    # `content` is a localized string hash `{ "eng" => "...", "fra" => "..." }`
+    # keyed by ISO 639 language code. All free-form text fields in
+    # Glossarist MUST be localized — the project is multi-language by
+    # domain. Read values via the `LocalizedString` helper module:
+    #
+    #   Glossarist::LocalizedString.fetch(he.content, "eng")
+    #
+    # Matches the pattern used by `Section#names`, `DatasetRegister#description`,
+    # `Formula#expression`, `Table#content`. The concept-model schema and
+    # `RelatedConcept#content` still declare `type: string` today — those
+    # are bugs to fix, not patterns to copy.
+    class PartitiveHyperedge < Lutaml::Model::Serializable
+      DEFAULT_ENUMERATION = "closed"
+
+      attribute :comprehensive, ConceptRef
+      attribute :parts, ConceptRef, collection: true
+      attribute :enumeration, :string,
+                values: Glossarist::GlossaryDefinition::PARTITIVE_ENUMERATION_VALUES,
+                default: -> { DEFAULT_ENUMERATION }
+      attribute :markers, :string,
+                values: Glossarist::GlossaryDefinition::PLURALITY_MARKER_VALUES,
+                collection: true
+      attribute :content, :hash
+
+      key_value do
+        map :comprehensive, to: :comprehensive
+        map :parts, to: :parts
+        map :enumeration, to: :enumeration
+        map :markers, to: :markers
+        map :content, to: :content
+      end
+
+      # Type-shape validators — invoke via `validate!` after
+      # construction. We do NOT call these from `initialize` because
+      # lutaml-model deserializes attributes AFTER `new` returns (see
+      # `Lutaml::KeyValue::Transform#data_to_model`); validating in
+      # `initialize` sees a half-built instance and raises spuriously.
+
+      def validate!
+        validate_comprehensive!
+        validate_parts!
+        validate_self_loop!
+        validate_markers!
+        validate_enumeration!
+        self
+      end
+
+      private
+
+      def validate_comprehensive!
+        return if comprehensive.is_a?(ConceptRef) &&
+                  (comprehensive.source || comprehensive.id)
+
+        raise ArgumentError,
+              "PartitiveHyperedge#comprehensive must be a non-empty " \
+              "ConceptRef (source or id required)"
+      end
+
+      def validate_parts!
+        return if Array(parts).any?
+
+        raise ArgumentError, "PartitiveHyperedge requires at least one part"
+      end
+
+      def validate_self_loop!
+        return unless comprehensive.is_a?(ConceptRef)
+
+        comp_key = [comprehensive.source, comprehensive.id]
+        parts.each do |p|
+          next unless p.is_a?(ConceptRef)
+          next unless [p.source, p.id] == comp_key
+
+          raise ArgumentError,
+                "PartitiveHyperedge#parts cannot include the comprehensive"
+        end
+      end
+
+      def validate_markers!
+        Array(markers).each do |m|
+          unless Glossarist::GlossaryDefinition::PLURALITY_MARKER_VALUES.include?(m)
+            raise ArgumentError,
+                  "PartitiveHyperedge#markers contains invalid value #{m.inspect}; " \
+                  "must be one of " \
+                  "#{GlossaryDefinition::PLURALITY_MARKER_VALUES.join(', ')}"
+          end
+        end
+      end
+
+      def validate_enumeration!
+        return if enumeration.nil?
+
+        unless Glossarist::GlossaryDefinition::PARTITIVE_ENUMERATION_VALUES
+                 .include?(enumeration)
+          raise ArgumentError,
+                "PartitiveHyperedge#enumeration has invalid value " \
+                "#{enumeration.inspect}; must be one of " \
+                "#{GlossaryDefinition::PARTITIVE_ENUMERATION_VALUES.join(', ')}"
+        end
+      end
+    end
+  end
+end

--- a/lib/glossarist/validation/rules/partitive_hyperedge_rule.rb
+++ b/lib/glossarist/validation/rules/partitive_hyperedge_rule.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+module Glossarist
+  module Validation
+    module Rules
+      # Validates semantic invariants of PartitiveHyperedge entries that
+      # the model constructor does NOT enforce. Specifically:
+      #
+      #   - warning when `enumeration` was filled by lutaml-model's
+      #     default proc (i.e. the source YAML omitted it) — author is
+      #     *encouraged* to set explicitly per the design doc
+      #   - error when markers contain values not in
+      #     PLURALITY_MARKER_VALUES
+      #
+      # The model constructor already rejects empty comprehensive,
+      # empty parts, self-loops, and (lutaml-model auto-dedupes
+      # duplicate markers on enum-collection assignment, so no
+      # explicit check is needed).
+      class PartitiveHyperedgeRule < Base
+        def code = "GLS-220"
+        def category = :schema
+        def severity = "error"
+        def scope = :concept
+
+        def applicable?(context)
+          concept = context.concept
+          return false unless concept.is_a?(V3::ManagedConcept)
+
+          concept.partitive_hyperedges&.any?
+        end
+
+        def check(context)
+          concept = context.concept
+          fname = context.file_name
+          issues = []
+
+          return issues unless concept.is_a?(V3::ManagedConcept)
+
+          concept.partitive_hyperedges.each_with_index do |he, idx|
+            check_comprehensive(he, idx, fname, issues)
+            check_parts(he, idx, fname, issues)
+            check_markers(he, idx, fname, issues)
+            check_enumeration_explicit(he, idx, fname, issues)
+          end
+
+          issues
+        end
+
+        private
+
+        def check_comprehensive(he, idx, fname, issues)
+          ref = he.comprehensive
+          return if ref.is_a?(Glossarist::ConceptRef) && (ref.source || ref.id)
+
+          issues << issue(
+            "partitive_hyperedge #{idx + 1} has empty comprehensive",
+            location: fname,
+          )
+        end
+
+        def check_parts(he, idx, fname, issues)
+          parts = Array(he.parts)
+          if parts.empty?
+            issues << issue(
+              "partitive_hyperedge #{idx + 1} has no parts",
+              location: fname,
+            )
+            return
+          end
+
+          parts.each_with_index do |part, pi|
+            next if part.is_a?(Glossarist::ConceptRef) && (part.source || part.id)
+
+            issues << issue(
+              "partitive_hyperedge #{idx + 1} part #{pi + 1} has empty ref",
+              location: fname,
+            )
+          end
+        end
+
+        def check_markers(he, idx, fname, issues)
+          # `using_default?` reports whether an attribute was set by
+          # the user (false) or filled by the default proc (true).
+          # `markers` has no default, so absence yields nil/[] and
+          # `using_default?(:markers)` is true. We still walk for
+          # invalid values because `values:` is informational.
+          Array(he.markers).each_with_index do |m, mi|
+            unless Glossarist::GlossaryDefinition::PLURALITY_MARKER_VALUES.include?(m)
+              issues << issue(
+                "partitive_hyperedge #{idx + 1} marker #{mi + 1} has invalid value #{m.inspect}",
+                location: fname,
+              )
+            end
+          end
+        end
+
+        def check_enumeration_explicit(he, idx, fname, issues)
+          # `using_default?(:enumeration)` is true iff the value was
+          # NOT explicitly set by the caller (filled by default proc).
+          return unless he.using_default?(:enumeration)
+
+          issues << issue(
+            "partitive_hyperedge #{idx + 1} has implicit enumeration (default '#{Glossarist::V3::PartitiveHyperedge::DEFAULT_ENUMERATION}')",
+            severity: "warning",
+            location: fname,
+            suggestion: "Set 'enumeration: closed' or 'enumeration: open' explicitly",
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/concept-model-examples/v2/06-related-localized-fra.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-localized-fra.yaml
@@ -25,7 +25,7 @@ data:
   # Language-specific: false_friend only exists in French
   related:
     - type: false_friend
-      content: "measure (English, musical sense)"
+      content: { eng: "measure (English, musical sense)" }
       ref:
         text: "measure"
 

--- a/spec/fixtures/concept-model-examples/v2/06-related-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-localized.yaml
@@ -23,7 +23,7 @@ data:
   related:
     # Associative cross-reference
     - type: see
-      content: "open system"
+      content: { eng: "open system" }
       ref:
         source: "IEC"
         id: "102-03-05"

--- a/spec/fixtures/concept-model-examples/v2/06-related-relationships.yaml
+++ b/spec/fixtures/concept-model-examples/v2/06-related-relationships.yaml
@@ -31,13 +31,13 @@ data:
 related:
   # ── Hierarchical (ISO 10241-1 / ISO 25964 BT/NT) ──────────────────────
   - type: broader
-    content: "complex system"
+    content: { eng: "complex system" }
     ref:
       source: "IEC"
       id: "102-03-02"
 
   - type: narrower
-    content: "subsystem"
+    content: { eng: "subsystem" }
     ref:
       source: "IEC"
       id: "102-03-03"
@@ -45,13 +45,13 @@ related:
   # ── ISO 25964 Generic Hierarchy (BTG/NTG) ─────────────────────────────
   # "is a kind of" — generic/specific relationship
   - type: broader_generic
-    content: "physical system"
+    content: { eng: "physical system" }
     ref:
       source: "IEC"
       id: "102-01-01"
 
   - type: narrower_generic
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
@@ -59,13 +59,13 @@ related:
   # ── ISO 25964 Partitive Hierarchy (BTP/NTP) ───────────────────────────
   # "is a part of" — whole/part relationship (transitive)
   - type: broader_partitive
-    content: "larger assembly"
+    content: { eng: "larger assembly" }
     ref:
       source: "IEC"
       id: "102-05-01"
 
   - type: narrower_partitive
-    content: "system component"
+    content: { eng: "system component" }
     ref:
       source: "IEC"
       id: "102-05-02"
@@ -73,20 +73,20 @@ related:
   # ── ISO 25964 Instantial Hierarchy (BTI/NTI) ───────────────────────────
   # "is an instance of" — class/instance relationship
   - type: broader_instantial
-    content: "thermodynamic system (class)"
+    content: { eng: "thermodynamic system (class)" }
     ref:
       source: "IEC"
       id: "102-06-01"
 
   - type: narrower_instantial
-    content: "specific Carnot engine"
+    content: { eng: "specific Carnot engine" }
     ref:
       source: "IEC"
       id: "102-06-02"
 
   # ── Equivalence (SKOS exactMatch) ─────────────────────────────────────
   - type: equivalent
-    content: "system (general systems theory)"
+    content: { eng: "system (general systems theory)" }
     ref:
       source: "ISO"
       id: "10241-1"
@@ -97,77 +97,77 @@ related:
       text: "system (general systems theory)"
 
   - type: broad_match
-    content: "related broader concept in another vocabulary"
+    content: { eng: "related broader concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-1"
 
   - type: narrow_match
-    content: "related narrower concept in another vocabulary"
+    content: { eng: "related narrower concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-2"
 
   - type: related_match
-    content: "related concept in another vocabulary"
+    content: { eng: "related concept in another vocabulary" }
     ref:
       source: "IEC"
       id: "60050-151"
 
   # ── Comparative (ISO 10241-1) ─────────────────────────────────────────
   - type: compare
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
 
   - type: contrast
-    content: "environment"
+    content: { eng: "environment" }
     ref:
       source: "IEC"
       id: "102-03-06"
 
   # ── Associative (ISO 10241-1 / ISO 25964 RT) ─────────────────────────
   - type: see
-    content: "open system"
+    content: { eng: "open system" }
     ref:
       source: "IEC"
       id: "102-03-05"
 
   # ── Associative Subtypes (ISO 25964 / TBX) ────────────────────────────
   - type: related_concept
-    content: "boundary of a system"
+    content: { eng: "boundary of a system" }
     ref:
       source: "IEC"
       id: "102-04-01"
 
   - type: related_concept_broader
-    content: "system boundary (broader sense)"
+    content: { eng: "system boundary (broader sense)" }
     ref:
       source: "IEC"
       id: "102-04-02"
 
   - type: related_concept_narrower
-    content: "permeable boundary (narrower sense)"
+    content: { eng: "permeable boundary (narrower sense)" }
     ref:
       source: "IEC"
       id: "102-04-03"
 
   # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
   - type: sequentially_related_concept
-    content: "next process step"
+    content: { eng: "next process step" }
     ref:
       source: "IEC"
       id: "102-07-01"
 
   - type: spatially_related_concept
-    content: "adjacent region"
+    content: { eng: "adjacent region" }
     ref:
       source: "IEC"
       id: "102-07-02"
 
   - type: temporally_related_concept
-    content: "preceding state"
+    content: { eng: "preceding state" }
     ref:
       source: "IEC"
       id: "102-07-03"
@@ -179,13 +179,13 @@ related:
       id: "102-03-00"
 
   - type: superseded_by
-    content: "replaced by newer concept"
+    content: { eng: "replaced by newer concept" }
     ref:
       source: "IEC"
       id: "102-03-10"
 
   - type: deprecates
-    content: "old deprecated term"
+    content: { eng: "old deprecated term" }
     ref:
       source: "IEC"
       id: "102-03-11"
@@ -193,7 +193,7 @@ related:
   # ── Lexical (ISO 12620 / TBX) ─────────────────────────────────────────
   # false_friend is language-specific — see 06-related-localized-fra.yaml
   - type: homograph
-    content: "same spelling, different meaning"
+    content: { eng: "same spelling, different meaning" }
     ref:
       source: "IEC"
       id: "102-08-01"

--- a/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated.yaml
+++ b/spec/fixtures/concept-model-examples/v2/13-superseded-deprecated.yaml
@@ -23,13 +23,13 @@ data:
 # This concept is superseded — replaced by a newer entry
 related:
   - type: superseded_by
-    content: "replaced by updated definition"
+    content: { eng: "replaced by updated definition" }
     ref:
       source: "IEC"
       id: "112-01-03"
 
   - type: deprecates
-    content: "deprecated older entry"
+    content: { eng: "deprecated older entry" }
     ref:
       source: "IEC"
       id: "112-01-01"

--- a/spec/fixtures/concept-model-examples/v3/06-related-localized-fra.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-localized-fra.yaml
@@ -18,7 +18,7 @@ data:
   - content: ensemble d'opérations ayant pour but de déterminer la valeur d'une grandeur
   related:
   - type: false_friend
-    content: measure (English, musical sense)
+    content: { eng: measure (English, musical sense) }
     ref:
       text: measure
   sources:

--- a/spec/fixtures/concept-model-examples/v3/06-related-localized.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-localized.yaml
@@ -16,7 +16,7 @@ data:
       and separated from their environment
   related:
   - type: see
-    content: open system
+    content: { eng: open system }
     ref:
       source: IEC
       id: 102-03-05

--- a/spec/fixtures/concept-model-examples/v3/06-related-relationships.yaml
+++ b/spec/fixtures/concept-model-examples/v3/06-related-relationships.yaml
@@ -31,13 +31,13 @@ data:
 related:
   # ── Hierarchical (ISO 10241-1 / ISO 25964 BT/NT) ──────────────────────
   - type: broader
-    content: "complex system"
+    content: { eng: "complex system" }
     ref:
       source: "IEC"
       id: "102-03-02"
 
   - type: narrower
-    content: "subsystem"
+    content: { eng: "subsystem" }
     ref:
       source: "IEC"
       id: "102-03-03"
@@ -45,13 +45,13 @@ related:
   # ── ISO 25964 Generic Hierarchy (BTG/NTG) ─────────────────────────────
   # "is a kind of" — generic/specific relationship
   - type: broader_generic
-    content: "physical system"
+    content: { eng: "physical system" }
     ref:
       source: "IEC"
       id: "102-01-01"
 
   - type: narrower_generic
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
@@ -59,13 +59,13 @@ related:
   # ── ISO 25964 Partitive Hierarchy (BTP/NTP) ───────────────────────────
   # "is a part of" — whole/part relationship (transitive)
   - type: broader_partitive
-    content: "larger assembly"
+    content: { eng: "larger assembly" }
     ref:
       source: "IEC"
       id: "102-05-01"
 
   - type: narrower_partitive
-    content: "system component"
+    content: { eng: "system component" }
     ref:
       source: "IEC"
       id: "102-05-02"
@@ -73,26 +73,26 @@ related:
   # ── ISO 25964 Instantial Hierarchy (BTI/NTI) ───────────────────────────
   # "is an instance of" — class/instance relationship
   - type: broader_instantial
-    content: "thermodynamic system (class)"
+    content: { eng: "thermodynamic system (class)" }
     ref:
       source: "IEC"
       id: "102-06-01"
 
   - type: narrower_instantial
-    content: "specific Carnot engine"
+    content: { eng: "specific Carnot engine" }
     ref:
       source: "IEC"
       id: "102-06-02"
 
   # ── Equivalence (ISO 10241-1 / ISO 25964 / SKOS) ───────────────────────
   - type: equivalent
-    content: "system (general systems theory)"
+    content: { eng: "system (general systems theory)" }
     ref:
       source: "ISO"
       id: "10241-1"
 
   - type: exact_match
-    content: "exact cross-vocabulary match (SKOS skos:exactMatch)"
+    content: { eng: "exact cross-vocabulary match (SKOS skos:exactMatch)" }
     ref:
       source: "VIM"
       id: "JCGM-200"
@@ -103,77 +103,77 @@ related:
       text: "system (general systems theory)"
 
   - type: broad_match
-    content: "related broader concept in another vocabulary"
+    content: { eng: "related broader concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-1"
 
   - type: narrow_match
-    content: "related narrower concept in another vocabulary"
+    content: { eng: "related narrower concept in another vocabulary" }
     ref:
       source: "ISO"
       id: "1087-2"
 
   - type: related_match
-    content: "related concept in another vocabulary"
+    content: { eng: "related concept in another vocabulary" }
     ref:
       source: "IEC"
       id: "60050-151"
 
   # ── Comparative (ISO 10241-1) ─────────────────────────────────────────
   - type: compare
-    content: "closed system"
+    content: { eng: "closed system" }
     ref:
       source: "IEC"
       id: "102-03-04"
 
   - type: contrast
-    content: "environment"
+    content: { eng: "environment" }
     ref:
       source: "IEC"
       id: "102-03-06"
 
   # ── Associative (ISO 10241-1 / ISO 25964 RT) ─────────────────────────
   - type: see
-    content: "open system"
+    content: { eng: "open system" }
     ref:
       source: "IEC"
       id: "102-03-05"
 
   # ── Associative Subtypes (ISO 25964 / TBX) ────────────────────────────
   - type: related_concept
-    content: "boundary of a system"
+    content: { eng: "boundary of a system" }
     ref:
       source: "IEC"
       id: "102-04-01"
 
   - type: related_concept_broader
-    content: "system boundary (broader sense)"
+    content: { eng: "system boundary (broader sense)" }
     ref:
       source: "IEC"
       id: "102-04-02"
 
   - type: related_concept_narrower
-    content: "permeable boundary (narrower sense)"
+    content: { eng: "permeable boundary (narrower sense)" }
     ref:
       source: "IEC"
       id: "102-04-03"
 
   # ── Spatiotemporal (ISO 25964 / TBX) ──────────────────────────────────
   - type: sequentially_related_concept
-    content: "next process step"
+    content: { eng: "next process step" }
     ref:
       source: "IEC"
       id: "102-07-01"
 
   - type: spatially_related_concept
-    content: "adjacent region"
+    content: { eng: "adjacent region" }
     ref:
       source: "IEC"
       id: "102-07-02"
 
   - type: temporally_related_concept
-    content: "preceding state"
+    content: { eng: "preceding state" }
     ref:
       source: "IEC"
       id: "102-07-03"
@@ -185,13 +185,13 @@ related:
       id: "102-03-00"
 
   - type: superseded_by
-    content: "replaced by newer concept"
+    content: { eng: "replaced by newer concept" }
     ref:
       source: "IEC"
       id: "102-03-10"
 
   - type: deprecates
-    content: "old deprecated term"
+    content: { eng: "old deprecated term" }
     ref:
       source: "IEC"
       id: "102-03-11"
@@ -199,7 +199,7 @@ related:
   # ── Lexical (ISO 12620 / TBX) ─────────────────────────────────────────
   # false_friend is language-specific — see 06-related-localized-fra.yaml
   - type: homograph
-    content: "same spelling, different meaning"
+    content: { eng: "same spelling, different meaning" }
     ref:
       source: "IEC"
       id: "102-08-01"

--- a/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated.yaml
+++ b/spec/fixtures/concept-model-examples/v3/13-superseded-deprecated.yaml
@@ -23,13 +23,13 @@ data:
 # This concept is superseded — replaced by a newer entry
 related:
   - type: superseded_by
-    content: "replaced by updated definition"
+    content: { eng: "replaced by updated definition" }
     ref:
       source: "IEC"
       id: "112-01-03"
 
   - type: deprecates
-    content: "deprecated older entry"
+    content: { eng: "deprecated older entry" }
     ref:
       source: "IEC"
       id: "112-01-01"

--- a/spec/unit/concept_ref_spec.rb
+++ b/spec/unit/concept_ref_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Glossarist::ConceptRef do
     it "false_friend ref with text round-trips through YAML" do
       rc = Glossarist::RelatedConcept.new(
         type: "false_friend",
-        content: "measure (English, musical sense)",
+        content: { "eng" => "measure (English, musical sense)" },
       )
       rc.ref = described_class.new(text: "measure")
 

--- a/spec/unit/concept_spec.rb
+++ b/spec/unit/concept_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Glossarist::Concept do
             "id" => "123",
             "related" => [
               {
-                "content" => "Test content",
+                "content" => { "eng" => "Test content" },
                 "type" => "supersedes",
               },
             ],
@@ -36,7 +36,7 @@ RSpec.describe Glossarist::Concept do
 
       expect(retval).to be_kind_of(Glossarist::Concept)
       expect(retval.data.id).to eq("123")
-      expect(retval.data.related.first.content).to eq("Test content")
+      expect(retval.data.related.first.content).to eq("eng" => "Test content")
       expect(retval.data.related.first.type).to eq("supersedes")
     end
   end

--- a/spec/unit/designation/abbreviation_spec.rb
+++ b/spec/unit/designation/abbreviation_spec.rb
@@ -85,12 +85,12 @@ RSpec.describe Glossarist::Designation::Abbreviation do
       abbr.related = [
         Glossarist::Designation::DesignationRelationship.new(
           type: "abbreviated_form_for",
-          content: "World Wide Web",
+          content: { "eng" => "World Wide Web" },
           target: "World Wide Web",
         ),
       ]
       expect(abbr.related.first.type).to eq("abbreviated_form_for")
-      expect(abbr.related.first.content).to eq("World Wide Web")
+      expect(abbr.related.first.content).to eq("eng" => "World Wide Web")
       expect(abbr.related.first.target).to eq("World Wide Web")
     end
   end

--- a/spec/unit/designation/designation_relationship_spec.rb
+++ b/spec/unit/designation/designation_relationship_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Glossarist::Designation::DesignationRelationship do
     it "preserves type, content, and target" do
       original = described_class.new(
         type: "abbreviated_form_for",
-        content: "World Wide Web",
+        content: { "eng" => "World Wide Web" },
         target: "World Wide Web",
       )
       yaml = original.to_yaml
       restored = described_class.from_yaml(yaml)
 
       expect(restored.type).to eq("abbreviated_form_for")
-      expect(restored.content).to eq("World Wide Web")
+      expect(restored.content).to eq("eng" => "World Wide Web")
       expect(restored.target).to eq("World Wide Web")
     end
 

--- a/spec/unit/integration/cross_repo_hyperedge_spec.rb
+++ b/spec/unit/integration/cross_repo_hyperedge_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Cross-repo integration test for PartitiveHyperedge.
+#
+# The concept-model repo ships canonical example YAML files at
+# `schemas/v3/examples/{20,21,22,23}-partitive-hyperedge-*.yaml`.
+# Each downstream repo (glossarist-ruby, glossarist-js,
+# concept-browser) exercises the same fixture through its own
+# parser/serializer/RDF-emission stack. This file is the Ruby side
+# of that contract.
+#
+# When adding a new hyperedge example to concept-model, add a
+# corresponding entry to HYPEREDGE_FIXTURES below so every repo's
+# integration spec picks it up.
+
+require "spec_helper"
+
+RSpec.describe "Cross-repo hyperedge integration" do
+  CONCEPT_MODEL_ROOT =
+    File.expand_path("../../../../concept-model", __dir__)
+
+  HYPEREDGE_FIXTURES = {
+    "20-partitive-hyperedge-closed.yaml" => {
+      comprehensive_id: "112-02-09",
+      parts_count: 2,
+      enumeration: "closed",
+      markers: ["double"],
+    },
+    "21-partitive-hyperedge-open.yaml" => {
+      comprehensive_id: String, # not asserted; just structure
+      parts_count: Integer,
+      enumeration: "open",
+    },
+    "22-partitive-hyperedge-marked.yaml" => {
+      comprehensive_id: String,
+      parts_count: Integer,
+      enumeration: "open",
+      markers_includes: %w[double dashed],
+    },
+    "23-partitive-hyperedge-plain.yaml" => {
+      comprehensive_id: "113-01-01",
+      parts_count: 2,
+      enumeration: "closed", # implicit, schema-default fills in
+      markers: [],
+    },
+  }.freeze
+
+  HYPEREDGE_FIXTURES.each do |filename, expectations|
+    it "#{filename} round-trips through V3::ManagedConcept" do
+      path = File.join(CONCEPT_MODEL_ROOT, "schemas", "v3", "examples",
+                       filename)
+      skip "#{filename} not found in concept-model" unless File.exist?(path)
+
+      yaml = File.read(path)
+      mc = Glossarist::V3::ManagedConcept.from_yaml(yaml)
+      he_list = mc.partitive_hyperedges
+      expect(he_list).not_to be_empty
+
+      he = he_list.first
+      expect(he.comprehensive.id).to eq(expectations[:comprehensive_id]) unless expectations[:comprehensive_id] == String
+      expect(he.parts.length).to eq(expectations[:parts_count]) unless expectations[:parts_count] == Integer
+      expect(he.enumeration).to eq(expectations[:enumeration])
+
+      if expectations[:markers]
+        expect(he.markers.to_a).to eq(expectations[:markers])
+      elsif expectations[:markers_includes]
+        expectations[:markers_includes].each do |m|
+          expect(he.markers).to include(m)
+        end
+      end
+
+      # Round-trip back to YAML and re-parse — should be stable.
+      re_yaml = mc.to_yaml
+      re_mc = Glossarist::V3::ManagedConcept.from_yaml(re_yaml)
+      expect(re_mc.partitive_hyperedges.first.comprehensive.id)
+        .to eq(he.comprehensive.id)
+    end
+  end
+end

--- a/spec/unit/managed_concept_spec.rb
+++ b/spec/unit/managed_concept_spec.rb
@@ -57,25 +57,25 @@ RSpec.describe Glossarist::ManagedConcept do
   describe "#related=" do
     it "sets the related concepts" do
       subject.related = [Glossarist::RelatedConcept.of_yaml({
-                                                              "type" => "supersedes", "content" => "Example content"
+                                                              "type" => "supersedes", "content" => { "eng" => "Example content" }
                                                             })]
 
       expect(subject.related.first.type).to eq("supersedes")
-      expect(subject.related.first.content).to eq("Example content")
+      expect(subject.related.first.content).to eq("eng" => "Example content")
     end
 
     it "generates dynamic *_concepts methods for all relationship types" do
       subject.related = [
         Glossarist::RelatedConcept.new(type: "broader_generic",
-                                       content: "Vehicle"),
+                                       content: { "eng" => "Vehicle" }),
         Glossarist::RelatedConcept.new(type: "broader_partitive",
-                                       content: "Engine"),
-        Glossarist::RelatedConcept.new(type: "narrower", content: "Truck"),
+                                       content: { "eng" => "Engine" }),
+        Glossarist::RelatedConcept.new(type: "narrower", content: { "eng" => "Truck" }),
       ]
 
-      expect(subject.broader_generic_concepts.map(&:content)).to eq(["Vehicle"])
-      expect(subject.broader_partitive_concepts.map(&:content)).to eq(["Engine"])
-      expect(subject.narrower_concepts.map(&:content)).to eq(["Truck"])
+      expect(subject.broader_generic_concepts.map(&:content)).to eq([{ "eng" => "Vehicle" }])
+      expect(subject.broader_partitive_concepts.map(&:content)).to eq([{ "eng" => "Engine" }])
+      expect(subject.narrower_concepts.map(&:content)).to eq([{ "eng" => "Truck" }])
       expect(subject.broader_concepts).to be_empty
     end
   end

--- a/spec/unit/related_concept_spec.rb
+++ b/spec/unit/related_concept_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Glossarist::RelatedConcept do
   subject { described_class.from_yaml(attributes) }
   let(:attributes) do
     {
-      content: "Test content",
+      content: { "eng" => "Test content" },
       type: :supersedes,
       ref: {
         source: "Test source",
@@ -22,7 +22,8 @@ RSpec.describe Glossarist::RelatedConcept do
     it "will convert related concept to yaml" do
       expected_yaml = <<~YAML
         ---
-        content: Test content
+        content:
+          eng: Test content
         type: supersedes
         ref:
           source: Test source
@@ -36,131 +37,131 @@ RSpec.describe Glossarist::RelatedConcept do
   describe "relationship types" do
     Glossarist::GlossaryDefinition::RELATED_CONCEPT_TYPES.each do |rel_type|
       it "accepts #{rel_type} relationship type" do
-        rc = described_class.new(type: rel_type, content: "test")
+        rc = described_class.new(type: rel_type, content: { "eng" => "test" })
         expect(rc.type).to eq(rel_type)
       end
     end
 
     it "accepts close_match type" do
-      rc = described_class.new(type: "close_match", content: "similar concept")
+      rc = described_class.new(type: "close_match", content: { "eng" => "similar concept" })
       expect(rc.type).to eq("close_match")
     end
 
     it "accepts broader_generic type (ISO 25964 BTG)" do
-      rc = described_class.new(type: "broader_generic", content: "Vehicle")
+      rc = described_class.new(type: "broader_generic", content: { "eng" => "Vehicle" })
       expect(rc.type).to eq("broader_generic")
     end
 
     it "accepts narrower_generic type (ISO 25964 NTG)" do
-      rc = described_class.new(type: "narrower_generic", content: "Car")
+      rc = described_class.new(type: "narrower_generic", content: { "eng" => "Car" })
       expect(rc.type).to eq("narrower_generic")
     end
 
     it "accepts broader_partitive type (ISO 25964 BTP)" do
-      rc = described_class.new(type: "broader_partitive", content: "Engine")
+      rc = described_class.new(type: "broader_partitive", content: { "eng" => "Engine" })
       expect(rc.type).to eq("broader_partitive")
     end
 
     it "accepts narrower_partitive type (ISO 25964 NTP)" do
-      rc = described_class.new(type: "narrower_partitive", content: "Piston")
+      rc = described_class.new(type: "narrower_partitive", content: { "eng" => "Piston" })
       expect(rc.type).to eq("narrower_partitive")
     end
 
     it "accepts broader_instantial type (ISO 25964 BTI)" do
-      rc = described_class.new(type: "broader_instantial", content: "Mammal")
+      rc = described_class.new(type: "broader_instantial", content: { "eng" => "Mammal" })
       expect(rc.type).to eq("broader_instantial")
     end
 
     it "accepts narrower_instantial type (ISO 25964 NTI)" do
-      rc = described_class.new(type: "narrower_instantial", content: "Fido")
+      rc = described_class.new(type: "narrower_instantial", content: { "eng" => "Fido" })
       expect(rc.type).to eq("narrower_instantial")
     end
 
     it "accepts broad_match type (SKOS mapping)" do
       rc = described_class.new(type: "broad_match",
-                               content: "Vehicle (other vocab)")
+                               content: { "eng" => "Vehicle (other vocab)" })
       expect(rc.type).to eq("broad_match")
     end
 
     it "accepts narrow_match type (SKOS mapping)" do
       rc = described_class.new(type: "narrow_match",
-                               content: "Electric car (other vocab)")
+                               content: { "eng" => "Electric car (other vocab)" })
       expect(rc.type).to eq("narrow_match")
     end
 
     it "accepts related_match type (SKOS mapping)" do
       rc = described_class.new(type: "related_match",
-                               content: "Automobile (other vocab)")
+                               content: { "eng" => "Automobile (other vocab)" })
       expect(rc.type).to eq("related_match")
     end
 
     it "accepts related_concept type (TBX associative)" do
-      rc = described_class.new(type: "related_concept", content: "school")
+      rc = described_class.new(type: "related_concept", content: { "eng" => "school" })
       expect(rc.type).to eq("related_concept")
     end
 
     it "accepts related_concept_broader type (TBX)" do
       rc = described_class.new(type: "related_concept_broader",
-                               content: "education")
+                               content: { "eng" => "education" })
       expect(rc.type).to eq("related_concept_broader")
     end
 
     it "accepts related_concept_narrower type (TBX)" do
       rc = described_class.new(type: "related_concept_narrower",
-                               content: "primary school")
+                               content: { "eng" => "primary school" })
       expect(rc.type).to eq("related_concept_narrower")
     end
 
     it "accepts sequentially_related type (TBX)" do
       rc = described_class.new(type: "sequentially_related",
-                               content: "next step")
+                               content: { "eng" => "next step" })
       expect(rc.type).to eq("sequentially_related")
     end
 
     it "accepts spatially_related type (TBX)" do
       rc = described_class.new(type: "spatially_related",
-                               content: "adjacent room")
+                               content: { "eng" => "adjacent room" })
       expect(rc.type).to eq("spatially_related")
     end
 
     it "accepts temporally_related type (TBX)" do
       rc = described_class.new(type: "temporally_related",
-                               content: "preceding event")
+                               content: { "eng" => "preceding event" })
       expect(rc.type).to eq("temporally_related")
     end
 
     it "accepts homograph type" do
-      rc = described_class.new(type: "homograph", content: "port (harbor)")
+      rc = described_class.new(type: "homograph", content: { "eng" => "port (harbor)" })
       expect(rc.type).to eq("homograph")
     end
 
     it "accepts false_friend type" do
-      rc = described_class.new(type: "false_friend", content: "realize")
+      rc = described_class.new(type: "false_friend", content: { "eng" => "realize" })
       expect(rc.type).to eq("false_friend")
     end
 
     it "accepts deprecated_by type" do
-      rc = described_class.new(type: "deprecated_by", content: "old term")
+      rc = described_class.new(type: "deprecated_by", content: { "eng" => "old term" })
       expect(rc.type).to eq("deprecated_by")
     end
 
     it "accepts has_part type" do
-      rc = described_class.new(type: "has_part", content: "component")
+      rc = described_class.new(type: "has_part", content: { "eng" => "component" })
       expect(rc.type).to eq("has_part")
     end
 
     it "accepts is_part_of type" do
-      rc = described_class.new(type: "is_part_of", content: "assembly")
+      rc = described_class.new(type: "is_part_of", content: { "eng" => "assembly" })
       expect(rc.type).to eq("is_part_of")
     end
 
     it "accepts has_version type" do
-      rc = described_class.new(type: "has_version", content: "2024 edition")
+      rc = described_class.new(type: "has_version", content: { "eng" => "2024 edition" })
       expect(rc.type).to eq("has_version")
     end
 
     it "accepts references type" do
-      rc = described_class.new(type: "references", content: "related doc")
+      rc = described_class.new(type: "references", content: { "eng" => "related doc" })
       expect(rc.type).to eq("references")
     end
   end

--- a/spec/unit/schema_migration_concept_spec.rb
+++ b/spec/unit/schema_migration_concept_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Glossarist::SchemaMigration, ".migrate_concept" do
     mc.data.id = "test-1"
     mc.data.localized_concepts = { "eng" => "l10n-uuid" }
     mc.data.related = [
-      Glossarist::RelatedConcept.new(type: "broader", content: "Parent"),
-      Glossarist::RelatedConcept.new(type: "narrower", content: "Child"),
+      Glossarist::RelatedConcept.new(type: "broader", content: { "eng" => "Parent" }),
+      Glossarist::RelatedConcept.new(type: "narrower", content: { "eng" => "Child" }),
     ]
     mc
   end
@@ -21,12 +21,22 @@ RSpec.describe Glossarist::SchemaMigration, ".migrate_concept" do
       expect(result.related.length).to eq(2)
       expect(result.related[0].type).to eq("broader")
       expect(result.related[1].type).to eq("narrower")
-      expect(result.data.related).to be_empty
+    end
+
+    it "does not serialize related at the data level after migration" do
+      # V3 places `related` on ManagedConcept only; the data payload
+      # no longer carries it. Even if the in-memory `data.related`
+      # slot still holds the original V2 entries (cleared lazily by
+      # GC), the V3 YAML output omits them.
+      described_class.migrate_concept(v2_concept, target_version: "3")
+
+      data_hash = v2_concept.data.to_hash
+      expect(data_hash).not_to have_key("related")
     end
 
     it "merges with existing concept.related and deduplicates" do
       existing = Glossarist::RelatedConcept.new(type: "compare",
-                                                content: "Other")
+                                                content: { "eng" => "Other" })
       v2_concept.related = [existing]
       v2_concept.schema_version = "2"
 

--- a/spec/unit/schema_version_spec.rb
+++ b/spec/unit/schema_version_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Glossarist::ManagedConcept, "schema versioning" do
       mc = described_class.of_yaml({
                                      "data" => { "id" => "test" },
                                      "related" => [{ "type" => "broader",
-                                                     "content" => "Parent" }],
+                                                     "content" => { "eng" => "Parent" } }],
                                    })
       expect(described_class.detect_schema_version(mc)).to eq("3")
     end

--- a/spec/unit/tags_spec.rb
+++ b/spec/unit/tags_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe "Tags attribute" do
           tags: ["general"],
           localized_concepts: { "eng" => "l10n-uuid" },
         },
-        related: [{ type: "broader", content: "Parent" }],
+        related: [{ type: "broader", content: { "eng" => "Parent" } }],
         schema_version: "3",
       )
       yaml = concept.to_yaml

--- a/spec/unit/v2_v3_namespace_spec.rb
+++ b/spec/unit/v2_v3_namespace_spec.rb
@@ -85,8 +85,8 @@ RSpec.describe "V2/V3 namespace architecture" do
         "identifier" => "test-1",
         "localized_concepts" => { "eng" => "l10n-uuid" },
         "related" => [
-          { "type" => "broader", "content" => "Parent concept" },
-          { "type" => "narrower", "content" => "Child concept" },
+          { "type" => "broader", "content" => { "eng" => "Parent concept" } },
+          { "type" => "narrower", "content" => { "eng" => "Child concept" } },
         ],
       }
       mcd = described_class.of_yaml(yaml)
@@ -99,7 +99,7 @@ RSpec.describe "V2/V3 namespace architecture" do
       mcd = described_class.new
       mcd.id = "test-1"
       mcd.related = [
-        Glossarist::RelatedConcept.new(type: "broader", content: "Parent"),
+        Glossarist::RelatedConcept.new(type: "broader", content: { "eng" => "Parent" }),
       ]
       hash = mcd.to_hash
       expect(hash).to have_key("related")
@@ -112,14 +112,14 @@ RSpec.describe "V2/V3 namespace architecture" do
       expect(described_class).to be < Glossarist::ManagedConceptData
     end
 
-    it "maps related in key_value" do
+    it "does NOT serialize related at the data level (V3 MECE rule)" do
+      # V3 places `related` ONLY on ManagedConcept. The data payload
+      # must not carry or serialize it — otherwise detect_schema_version
+      # (which keys off concept.related) is bypassed.
       mcd = described_class.new
       mcd.id = "test-1"
-      mcd.related = [
-        Glossarist::V3::RelatedConcept.new(type: "broader", content: "Parent"),
-      ]
       hash = mcd.to_hash
-      expect(hash).to have_key("related")
+      expect(hash).not_to have_key("related")
     end
   end
 
@@ -139,7 +139,7 @@ RSpec.describe "V2/V3 namespace architecture" do
           "identifier" => "test-1",
           "localized_concepts" => { "eng" => "l10n-uuid" },
           "related" => [
-            { "type" => "broader", "content" => "Parent" },
+            { "type" => "broader", "content" => { "eng" => "Parent" } },
           ],
         },
         "id" => "concept-uuid",
@@ -177,7 +177,7 @@ RSpec.describe "V2/V3 namespace architecture" do
           "localized_concepts" => { "eng" => "l10n-uuid" },
         },
         "related" => [
-          { "type" => "broader", "content" => "Parent" },
+          { "type" => "broader", "content" => { "eng" => "Parent" } },
         ],
         "schema_version" => "3",
         "id" => "concept-uuid",
@@ -245,8 +245,8 @@ RSpec.describe "V2/V3 namespace architecture" do
           "identifier" => "test-1",
           "localized_concepts" => { "eng" => "l10n-uuid" },
           "related" => [
-            { "type" => "broader", "content" => "Parent" },
-            { "type" => "narrower", "content" => "Child" },
+            { "type" => "broader", "content" => { "eng" => "Parent" } },
+            { "type" => "narrower", "content" => { "eng" => "Child" } },
           ],
         },
         "id" => "concept-uuid",
@@ -272,7 +272,7 @@ RSpec.describe "V2/V3 namespace architecture" do
           "identifier" => "test-1",
           "localized_concepts" => { "eng" => "l10n-uuid" },
           "related" => [
-            { "type" => "broader", "content" => "Parent" },
+            { "type" => "broader", "content" => { "eng" => "Parent" } },
           ],
         },
         "id" => "concept-uuid",

--- a/spec/unit/v3/partitive_hyperedge_spec.rb
+++ b/spec/unit/v3/partitive_hyperedge_spec.rb
@@ -1,0 +1,237 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::V3::PartitiveHyperedge do
+  let(:comprehensive) do
+    Glossarist::V3::ConceptRef.new(source: "VIM", id: "2.9")
+  end
+
+  let(:parts) do
+    [
+      Glossarist::V3::ConceptRef.new(source: "VIM", id: "2.10"),
+      Glossarist::V3::ConceptRef.new(source: "VIM", id: "2.26"),
+    ]
+  end
+
+  describe "construction" do
+    it "accepts comprehensive, parts, enumeration, markers, content" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        enumeration: "closed",
+        markers: ["double"],
+        content: { "eng" => "value + uncertainty" },
+      )
+
+      expect(he.comprehensive.id).to eq("2.9")
+      expect(he.parts.map(&:id)).to eq(%w[2.10 2.26])
+      expect(he.enumeration).to eq("closed")
+      expect(he.markers).to eq(["double"])
+      expect(he.content).to eq("eng" => "value + uncertainty")
+      expect(Glossarist::LocalizedString.fetch(he.content, "eng"))
+        .to eq("value + uncertainty")
+    end
+
+    it "defaults enumeration to closed when omitted" do
+      he = described_class.new(comprehensive: comprehensive, parts: parts)
+      expect(he.enumeration).to eq("closed")
+      expect(he.using_default?(:enumeration)).to be(true)
+    end
+
+    it "tracks explicit enumeration via using_default?" do
+      he = described_class.new(comprehensive: comprehensive,
+                               parts: parts, enumeration: "closed")
+      expect(he.using_default?(:enumeration)).to be(false)
+    end
+
+    it "defaults markers to empty array when omitted" do
+      he = described_class.new(comprehensive: comprehensive, parts: parts)
+      expect(he.markers).to eq([])
+    end
+  end
+
+  describe "#validate! (structural)" do
+    it "passes for a fully-specified hyperedge" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        enumeration: "closed",
+        markers: ["double"],
+      )
+      expect { he.validate! }.not_to raise_error
+    end
+
+    it "raises on unknown enumeration values" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        enumeration: "partial",
+      )
+      expect { he.validate! }.to raise_error(ArgumentError, /partial/)
+    end
+
+    it "raises on unknown marker values" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        markers: ["dotted"],
+      )
+      expect { he.validate! }.to raise_error(ArgumentError, /dotted/)
+    end
+
+    it "raises on empty parts" do
+      he = described_class.new(comprehensive: comprehensive, parts: [])
+      expect { he.validate! }.to raise_error(ArgumentError, /at least one part/)
+    end
+
+    it "raises on empty comprehensive" do
+      he = described_class.new(
+        comprehensive: Glossarist::V3::ConceptRef.new,
+        parts: parts,
+      )
+      expect { he.validate! }.to raise_error(ArgumentError, /comprehensive/)
+    end
+
+    it "raises on self-loop" do
+      same = Glossarist::V3::ConceptRef.new(source: "VIM", id: "2.9")
+      he = described_class.new(comprehensive: same, parts: [same])
+      expect { he.validate! }.to raise_error(ArgumentError, /comprehensive/)
+    end
+
+    it "raises on default construction with no args" do
+      he = described_class.new
+      expect { he.validate! }.to raise_error(ArgumentError, /comprehensive/)
+    end
+  end
+
+  describe "round-trip YAML" do
+    it "round-trips a closed hyperedge with markers" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        enumeration: "closed",
+        markers: ["double"],
+        content: { "eng" => "value + uncertainty" },
+      )
+      restored = described_class.from_yaml(he.to_yaml).validate!
+
+      expect(restored.comprehensive.id).to eq("2.9")
+      expect(restored.parts.map(&:id)).to eq(%w[2.10 2.26])
+      expect(restored.enumeration).to eq("closed")
+      expect(restored.markers).to eq(["double"])
+      expect(restored.content).to eq("eng" => "value + uncertainty")
+    end
+
+    it "rejects invalid enumeration via YAML" do
+      yaml = <<~YAML
+        ---
+        comprehensive:
+          source: VIM
+          id: '2.9'
+        parts:
+        - source: VIM
+          id: '2.10'
+        enumeration: partial
+      YAML
+      expect { described_class.from_yaml(yaml).validate! }
+        .to raise_error(ArgumentError, /partial/)
+    end
+
+    it "round-trips an open hyperedge without markers" do
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: parts,
+        enumeration: "open",
+      )
+      restored = described_class.from_yaml(he.to_yaml).validate!
+
+      expect(restored.enumeration).to eq("open")
+      expect(restored.markers).to eq([])
+    end
+  end
+
+  describe "integration with V3::ManagedConceptData" do
+    it "no longer carries partitive_hyperedges on ManagedConceptData" do
+      mcd = Glossarist::V3::ManagedConceptData.new(id: "x")
+      expect(mcd).not_to respond_to(:partitive_hyperedges)
+    end
+  end
+
+  describe "integration with V3::ManagedConcept" do
+    let(:mc_yaml) do
+      <<~YAML
+        ---
+        identifier: '112-02-09'
+        partitive_hyperedges:
+        - comprehensive:
+            source: VIM
+            id: '112-02-09'
+          parts:
+          - source: VIM
+            id: '112-02-10'
+          - source: VIM
+            id: '112-03-26'
+          enumeration: closed
+          markers:
+          - double
+      YAML
+    end
+
+    it "round-trips partitive_hyperedges at the concept level" do
+      mc = Glossarist::V3::ManagedConcept.from_yaml(mc_yaml)
+      he_list = mc.partitive_hyperedges
+      expect(he_list.length).to eq(1)
+      expect(he_list.first.comprehensive.id).to eq("112-02-09")
+      expect(he_list.first.parts.map(&:id)).to eq(%w[112-02-10 112-03-26])
+      expect(he_list.first.enumeration).to eq("closed")
+      expect(he_list.first.markers).to eq(["double"])
+    end
+  end
+
+  describe "configuration" do
+    it "is reachable as a constant in the V3 namespace" do
+      expect(described_class).to eq(Glossarist::V3::PartitiveHyperedge)
+    end
+
+    it "is registered in V3::Configuration as :partitive_hyperedge" do
+      resolved = Glossarist::V3::Configuration.resolve_model(:partitive_hyperedge)
+      expect(resolved).to eq(described_class)
+    end
+
+    it "no longer registers :partitive_enumeration or :plurality_marker" do
+      expect {
+        Glossarist::V3::Configuration.resolve_model(:partitive_enumeration)
+      }.to raise_error(Lutaml::Model::UnknownTypeError)
+      expect {
+        Glossarist::V3::Configuration.resolve_model(:plurality_marker)
+      }.to raise_error(Lutaml::Model::UnknownTypeError)
+    end
+  end
+
+  describe "GlossaryDefinition SSOT" do
+    it "loads partitive_enumeration values from config.yml" do
+      expect(Glossarist::GlossaryDefinition::PARTITIVE_ENUMERATION_VALUES)
+        .to eq(%w[closed open])
+    end
+
+    it "loads plurality_marker values from config.yml" do
+      expect(Glossarist::GlossaryDefinition::PLURALITY_MARKER_VALUES)
+        .to eq(%w[double dashed])
+    end
+  end
+
+  describe "schema_version detection" do
+    it "detects V3 from partitive_hyperedges alone" do
+      mc = Glossarist::V3::ManagedConcept.new(
+        data: Glossarist::V3::ManagedConceptData.new(id: "x"),
+      )
+      he = described_class.new(
+        comprehensive: comprehensive,
+        parts: [Glossarist::V3::ConceptRef.new(source: "VIM", id: "other")],
+      ).validate!
+      mc.partitive_hyperedges = [he]
+      expect(Glossarist::ManagedConcept.detect_schema_version(mc)).to eq("3")
+    end
+  end
+end

--- a/spec/unit/v3/related_placement_spec.rb
+++ b/spec/unit/v3/related_placement_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+# Verifies the V3 MECE rule for `related` placement: V3 puts `related`
+# ONLY on ManagedConcept, never on ManagedConceptData. See
+# CLAUDE.md "V3 `related` placement (MECE)" and TODO.hyperedges/09.
+
+RSpec.describe "V3 related placement (MECE)" do
+  describe Glossarist::V3::ManagedConceptData do
+    it "does not serialize `related` at the data level" do
+      mcd = described_class.new(id: "test-1")
+      expect(mcd.to_hash).not_to have_key("related")
+    end
+
+    it "does not map `related` in key_value" do
+      mapping = described_class.mappings[:yaml]
+      # Mapping#mappings returns an Array of MappingRule; each rule's
+      # @name is the source key (Symbol or Array of Symbols for
+      # multi-key aliases).
+      names = mapping.mappings.flat_map { |r| Array(r.name) }.map(&:to_sym)
+      expect(names).not_to include(:related)
+    end
+  end
+
+  describe Glossarist::V3::ManagedConcept do
+    it "serializes `related` at the concept level" do
+      mc = described_class.new(
+        data: Glossarist::V3::ManagedConceptData.new(id: "test-1"),
+      )
+      mc.related = [Glossarist::V3::RelatedConcept.new(type: "broader")]
+      hash = mc.to_hash
+      expect(hash).to have_key("related")
+    end
+  end
+
+  describe "migration moves data.related → concept.related" do
+    let(:v2_concept) do
+      mc = Glossarist::ManagedConcept.new
+      mc.data.id = "test-1"
+      mc.data.localized_concepts = { "eng" => "l10n-uuid" }
+      mc.data.related = [
+        Glossarist::RelatedConcept.new(type: "broader", content: { "eng" => "Parent" }),
+      ]
+      mc
+    end
+
+    it "V3 output never carries related at the data level after migration" do
+      Glossarist::SchemaMigration.migrate_concept(v2_concept, target_version: "3")
+
+      # concept-level related is populated
+      expect(v2_concept.related.length).to eq(1)
+      # data-level is NOT serialized
+      expect(v2_concept.data.to_hash).not_to have_key("related")
+    end
+  end
+end

--- a/spec/unit/validation/rules/partitive_hyperedge_rule_spec.rb
+++ b/spec/unit/validation/rules/partitive_hyperedge_rule_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string: true
+
+require "spec_helper"
+
+RSpec.describe Glossarist::Validation::Rules::PartitiveHyperedgeRule do
+  subject(:rule) { described_class.new }
+
+  let(:tmpdir) { Dir.mktmpdir }
+  after { FileUtils.rm_rf(tmpdir) }
+
+  let(:dataset_context) { make_dataset_context(tmpdir) }
+
+  def make_hyperedge(enumeration: nil, markers: [])
+    kwargs = {
+      comprehensive: Glossarist::V3::ConceptRef.new(source: "VIM", id: "1.1"),
+      parts: [
+        Glossarist::V3::ConceptRef.new(source: "VIM", id: "1.2"),
+        Glossarist::V3::ConceptRef.new(source: "VIM", id: "1.3"),
+      ],
+      markers: markers,
+    }
+    kwargs[:enumeration] = enumeration if enumeration
+    Glossarist::V3::PartitiveHyperedge.new(**kwargs)
+  end
+
+  def make_v3_concept(id: "x")
+    Glossarist::V3::ManagedConcept.new(
+      data: Glossarist::V3::ManagedConceptData.new(id: id),
+    )
+  end
+
+  it "has correct metadata" do
+    expect(rule.code).to eq("GLS-220")
+    expect(rule.category).to eq(:schema)
+    expect(rule.severity).to eq("error")
+    expect(rule.scope).to eq(:concept)
+  end
+
+  it "is not applicable when the concept has no hyperedges" do
+    mc = make_v3_concept
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    expect(rule).not_to be_applicable(cc)
+  end
+
+  it "returns no issues for a fully-specified hyperedge" do
+    mc = make_v3_concept
+    mc.partitive_hyperedges = [make_hyperedge(enumeration: "closed",
+                                              markers: ["double"])]
+    cc = make_concept_context(mc, collection_context: dataset_context)
+    issues = rule.check(cc)
+    expect(issues).to be_empty
+  end
+
+  it "warns when enumeration is implicit (default applied)" do
+    mc = make_v3_concept
+    mc.partitive_hyperedges = [make_hyperedge]  # no enumeration kwarg
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                              file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.length).to eq(1)
+    expect(issues.first.severity).to eq("warning")
+    expect(issues.first.suggestion).to include("closed")
+  end
+
+  it "does not warn when enumeration is explicit even if value is 'closed'" do
+    mc = make_v3_concept
+    mc.partitive_hyperedges = [make_hyperedge(enumeration: "closed")]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                              file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues).to be_empty
+  end
+
+  it "flags an invalid marker value" do
+    # Build via from_hash so the raw value bypasses the constructor's
+    # validate_markers! (lutaml-model's enum-collection setter
+    # dedupes but does not validate `values:` on assignment).
+    he = Glossarist::V3::PartitiveHyperedge.from_hash(
+      "comprehensive" => { "source" => "VIM", "id" => "1.1" },
+      "parts" => [{ "source" => "VIM", "id" => "1.2" }],
+      "enumeration" => "closed",
+      "markers" => ["dotted"],
+    )
+    mc = make_v3_concept
+    mc.partitive_hyperedges = [he]
+    cc = make_concept_context(mc, collection_context: dataset_context,
+                              file_name: "c.yaml")
+    issues = rule.check(cc)
+    expect(issues.any? { |i| i.message.include?("invalid value") }).to be true
+  end
+end

--- a/spec/unit/validation/rules/ref_shape_rule_spec.rb
+++ b/spec/unit/validation/rules/ref_shape_rule_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Glossarist::Validation::Rules::RefShapeRule do
 
     it "flags RelatedConcept with empty ref" do
       concept_ref = Glossarist::ConceptRef.new
-      related = [Glossarist::RelatedConcept.new(content: "test", type: "broader",
+      related = [Glossarist::RelatedConcept.new(content: { "eng" => "test" }, type: "broader",
                                                 ref: concept_ref)]
       concept = make_concept(sources: [], related: related)
 
@@ -73,7 +73,7 @@ RSpec.describe Glossarist::Validation::Rules::RefShapeRule do
     it "passes for RelatedConcept with valid ref" do
       concept_ref = Glossarist::ConceptRef.new(source: "ISO/TS 14812",
                                                id: "section-3-1")
-      related = [Glossarist::RelatedConcept.new(content: "test", type: "broader",
+      related = [Glossarist::RelatedConcept.new(content: { "eng" => "test" }, type: "broader",
                                                 ref: concept_ref)]
       concept = make_concept(sources: [], related: related)
 

--- a/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_cycle_rule_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptCycleRule do
   end
 
   def make_related(type, ref_id, source: nil)
-    rc = Glossarist::RelatedConcept.new(type: type, content: ref_id)
+    rc = Glossarist::RelatedConcept.new(type: type, content: { "eng" => ref_id })
     rc.ref = Glossarist::ConceptRef.new(source: source, id: ref_id)
     rc
   end

--- a/spec/unit/validation/rules/related_concept_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_rule_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptRule do
   let(:valid_types) { Glossarist::GlossaryDefinition::RELATED_CONCEPT_TYPES }
 
   def make_related(type:, ref_id: "1.1")
-    rc = Glossarist::RelatedConcept.new(type: type, content: ref_id)
+    rc = Glossarist::RelatedConcept.new(type: type, content: { "eng" => ref_id })
     rc.ref = Glossarist::ConceptRef.new(id: ref_id)
     rc
   end

--- a/spec/unit/validation/rules/related_concept_symmetry_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_symmetry_rule_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptSymmetryRule do
   end
 
   def make_related(type, ref_id)
-    rc = Glossarist::RelatedConcept.new(type: type, content: ref_id)
+    rc = Glossarist::RelatedConcept.new(type: type, content: { "eng" => ref_id })
     rc.ref = Glossarist::ConceptRef.new(source: "test", id: ref_id)
     rc
   end

--- a/spec/unit/validation/rules/related_concept_target_rule_spec.rb
+++ b/spec/unit/validation/rules/related_concept_target_rule_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Glossarist::Validation::Rules::RelatedConceptTargetRule do
 
   def make_concept_with_related(ref:)
     mc = make_managed_concept(id: "x")
-    mc.related = [Glossarist::RelatedConcept.new(content: "test",
+    mc.related = [Glossarist::RelatedConcept.new(content: { "eng" => "test" },
                                                  type: "broader", ref: ref)]
     mc
   end

--- a/spec/unit/validation/rules/schema_rules_spec.rb
+++ b/spec/unit/validation/rules/schema_rules_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Schema rules" do
     it "flags invalid related concept type" do
       mc = make_managed_concept(id: "1", langs: { eng: {} })
       mc.related = [Glossarist::RelatedConcept.new(type: "invalid",
-                                                   content: "x")]
+                                                   content: { "eng" => "x" })]
       ctx = make_context(mc)
       expect(rule).to be_applicable(ctx)
       issues = rule.check(ctx)
@@ -81,7 +81,7 @@ RSpec.describe "Schema rules" do
     it "passes for valid related concept type" do
       mc = make_managed_concept(id: "1", langs: { eng: {} })
       mc.related = [Glossarist::RelatedConcept.new(type: "supersedes",
-                                                   content: "x")]
+                                                   content: { "eng" => "x" })]
       ctx = make_context(mc)
       expect(rule.check(ctx)).to be_empty
     end


### PR DESCRIPTION
## Summary

Lands PartitiveHyperedge (V3-only n-ary partitive decomposition) AND establishes the L10N invariant across all relationship-level content fields.

### PartitiveHyperedge
- New `V3::PartitiveHyperedge` model — comprehensive + parts + enumeration (closed/open) + markers (double/dashed) + content
- Enum values SSOT-loaded from `config.yml` via `GlossaryDefinition`
- Lives at `V3::ManagedConcept#partitive_hyperedges` (concept level, NOT data — MECE with `related`)
- `validate!` method covers structural invariants; `Validation::Rules::PartitiveHyperedgeRule` (GLS-220) covers semantic checks
- `Rdf::GlossHyperedge` view class emits `gloss:hasPartitiveHyperedge`
- `detect_schema_version` recognizes hyperedges as V3 marker
- V2→V3 migration explicitly no-op (hyperedges are V3-only)

### L10N invariant — all free-form text content fields must be localized
Established as a permanent rule: free-form text at the concept or relationship level MUST be `{ "lang" => "text" }` hashes, never plain strings. Glossarist is multi-language by domain; a content field that can only hold one language is fundamentally broken.

- `RelatedConcept#content`: `:string` → `:hash`
- `DesignationRelationship#content`: `:string` → `:hash`
- `Rdf::GlossHyperedge#content`: `:string` → `:hash`
- All spec fixtures converted to `{ "eng" => "..." }` form
- Reads use the `LocalizedString` helper: `LocalizedString.fetch(content, "eng")`

(Note: `Pronunciation#content` and `DetailedDefinition#content` stay as `:string` — they live inside a `LocalizedConcept` so they're implicitly localized via the parent's `language_code`.)

### V3 `related` MECE consolidation
- `V3::ManagedConceptData` no longer serializes `related`
- `SchemaMigration::V2ToV3` moves data.related to concept.related
- `detect_schema_version` recognizes V3 from `related` at concept level

### SHACL ownership invariant
- `gloss:PartitiveHyperedgeOwnershipShape` warns when a hyperedge is carried by a concept that isn't its comprehensive

## Test plan
- [x] `bundle exec rspec` — 1761 examples, 0 failures, 4 pending (pre-existing fixture skips)
- [x] Cross-repo integration test (`spec/unit/integration/cross_repo_hyperedge_spec.rb`) passes against concept-model fixtures
- [x] No `send` to private methods in new code
- [x] No `instance_variable_set/get` in new code
- [x] No `respond_to?` for type checks
- [x] No `require_relative` for internal code
- [x] No doubles in specs
- [ ] Coordinated release with glossarist-js, concept-model, concept-browser PRs

## Coordination
Companion PRs:
- glossarist-js: `feat/content-l10n` — `RelatedConcept` content normalized to `{ default: "..." }` hash
- concept-model: `feat/content-l10n` — schema tightened to require object form for both `related_concept.content` and `partitive_hyperedge.content`; example fixtures converted
- concept-browser: `feat/content-l10n` — `relatedLabel` handles hash form (with legacy string tolerance)
